### PR TITLE
[github] Add to issues user data from the GitHub User API (email, company ...)

### DIFF
--- a/perceval/backends/github.py
+++ b/perceval/backends/github.py
@@ -80,7 +80,7 @@ class GitHub(Backend):
 
         if field not in fields:
             logging.warning("Wrong user field %s" % (field))
-            return []
+            return {}
 
         # Add user data: user and assignee
         if issue[field]:

--- a/perceval/backends/github.py
+++ b/perceval/backends/github.py
@@ -112,7 +112,10 @@ class GitHub(Backend):
             issues = json.loads(raw_issues)
             for issue in issues:
                 for field in ['user', 'assignee']:
-                    issue[field+"_data"] = self._get_user(issue[field]['login'])
+                    if issue[field]:
+                        issue[field+"_data"] = self._get_user(issue[field]['login'])
+                    else:
+                        issue[field+"_data"] = {}
                 yield issue
 
     @metadata(get_update_time)


### PR DESCRIPTION
Add also the cache support for users.

The users in an issue are: "user", "assignee". Both of them have now extra user data retrieved from GitHub User API.