### PR TITLE
[git] Fix carriage return not in end of line

### DIFF
--- a/perceval/backends/git.py
+++ b/perceval/backends/git.py
@@ -154,7 +154,8 @@ class Git(Backend):
         :raises OSError: raised when an error occurs reading the
             given file
         """
-        with open(filepath, 'r', errors='surrogateescape') as f:
+        with open(filepath, 'r', errors='surrogateescape',
+                  newline=os.linesep) as f:
             parser = GitParser(f)
 
             for commit in parser.parse():

--- a/tests/data/git_bad_cr.txt
+++ b/tests/data/git_bad_cr.txt
@@ -1,0 +1,13 @@
+commit 2d137c24e9f433e37ffd10b3d5f418157589a8d2 baaa2c512dc1c47e3afeb9d558c5323c9240bd21
+Author:     akpm@osdl.org <akpm@osdl.org>
+AuthorDate: Sat Apr 16 15:23:55 2005 -0700
+Commit:     Linus Torvalds <torvalds@ppc970.osdl.org>
+CommitDate: Sat Apr 16 15:23:55 2005 -0700
+
+    [PATCH] arm: fix SIGBUS handling
+    
+    )
+    
+:100644 100644 29be1c0... e25b4fd... M	arch/arm/mm/fault.c
+36	44	arch/arm/mm/fault.c
+

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -204,6 +204,21 @@ class TestGitBackend(unittest.TestCase):
         self.assertEqual(commit['commit'], 'cb24e4f2f7b2a7f3450bfb15d1cbaa97371e93fb')
         self.assertEqual(commit['message'], 'Calling \udc93Open Type\udc94 (CTRL+SHIFT+T) after startup - performance improvement.')
 
+    def test_git_cr_error(self):
+        """Test if mislocated carriage return chars do not break lines
+
+        In some commit messages, carriage return characters (\r) are found
+        in weird places. They should not be misconsidered as end of line.
+
+        Before fixing, this test raises an exception:
+        "perceval.errors.ParseError: commit expected on line 10"
+
+        """
+
+        commits = Git.parse_git_log_from_file("data/git_bad_cr.txt")
+        result = [commit for commit in commits]
+        self.assertEqual(len(result), 1)
+
     def test_git_parser_from_iter(self):
         """Test if the static method parses a git log from a repository"""
 


### PR DESCRIPTION
In some commit messages, there is a carriage return character
not in the end of a line. This caused a wrong line break which
caused the parser to misidentify the end of the message.

Fixes #21