### PR TITLE
[Gerrit] Add --blacklist-reviews option

### DIFF
--- a/perceval/backends/gerrit.py
+++ b/perceval/backends/gerrit.py
@@ -265,7 +265,7 @@ class GerritClient():
         cmd += "limit:" + str(self.max_reviews)
 
         if self.blacklist_reviews:
-            blacklist_reviews = ' AND NOT (%s)' % (self.blacklist_reviews)
+            blacklist_reviews = ' AND NOT (%s)' % (','.join(self.blacklist_reviews))
             cmd += " '(status:open OR status:closed)%s' " % (blacklist_reviews)
         else:
             cmd += " '(status:open OR status:closed)' "
@@ -360,7 +360,6 @@ class GerritCommand(BackendCommand):
                            type=int, default=MAX_REVIEWS,
                            help="Max number of reviews per ssh query.")
         group.add_argument("--blacklist-reviews",  dest="blacklist_reviews",
-                           type=str,
-                           help="Wrong reviews that must not be retrieved. Comma separated list.")
+                           nargs='*', help="Wrong reviews that must not be retrieved.")
 
         return parser

--- a/perceval/backends/gerrit.py
+++ b/perceval/backends/gerrit.py
@@ -186,7 +186,7 @@ class GerritClient():
     CMD_VERSION = 'version'
     PORT = '29418'
 
-    def __init__(self, repository, user, max_reviews, blacklist_reviews=None):
+    def __init__(self, repository, user, max_reviews, blacklist_reviews=[]):
         self.gerrit_user = user
         self.max_reviews = max_reviews
         self.blacklist_reviews = blacklist_reviews

--- a/perceval/backends/gerrit.py
+++ b/perceval/backends/gerrit.py
@@ -53,11 +53,14 @@ class Gerrit(Backend):
     """
     version = '0.1.0'
 
-    def __init__(self, url, user=None, max_reviews=None, cache=None):
+    def __init__(self, url, user=None, max_reviews=None, cache=None,
+                 blacklist_reviews=None):
         super().__init__(url, cache=cache)
         self.url = url
         self.max_reviews = max_reviews
-        self.client = GerritClient(self.url, user, max_reviews)
+        self.blacklist_reviews = blacklist_reviews
+        self.client = GerritClient(self.url, user, max_reviews,
+                                   blacklist_reviews)
 
     @metadata
     def fetch(self, from_date=DEFAULT_DATETIME):
@@ -183,9 +186,10 @@ class GerritClient():
     CMD_VERSION = 'version'
     PORT = '29418'
 
-    def __init__(self, repository, user, max_reviews):
+    def __init__(self, repository, user, max_reviews, blacklist_reviews=None):
         self.gerrit_user = user
         self.max_reviews = max_reviews
+        self.blacklist_reviews = blacklist_reviews
         self.repository = repository
         self.project = None
         self._version = None
@@ -260,8 +264,11 @@ class GerritClient():
             cmd += "project:"+self.project+" "
         cmd += "limit:" + str(self.max_reviews)
 
-        # This does not work for Wikimedia 2.8.1 version
-        cmd += " '(status:open OR status:closed)' "
+        if self.blacklist_reviews:
+            blacklist_reviews = ' AND NOT (%s)' % (self.blacklist_reviews)
+            cmd += " '(status:open OR status:closed)%s' " % (blacklist_reviews)
+        else:
+            cmd += " '(status:open OR status:closed)' "
 
         cmd += " --all-approvals --comments --format=JSON"
 
@@ -285,6 +292,7 @@ class GerritCommand(BackendCommand):
         self.url = self.parsed_args.url
         self.user = self.parsed_args.user
         self.max_reviews = self.parsed_args.max_reviews
+        self.blacklist_reviews = self.parsed_args.blacklist_reviews
         self.from_date = str_to_datetime(self.parsed_args.from_date)
         self.outfile = self.parsed_args.outfile
 
@@ -305,7 +313,8 @@ class GerritCommand(BackendCommand):
             cache = None
 
         self.backend = Gerrit(self.url, self.user,
-                              self.max_reviews, cache=cache)
+                              self.max_reviews, cache=cache,
+                              blacklist_reviews=self.blacklist_reviews)
 
     def run(self):
         """Fetch and print the reviews.
@@ -350,5 +359,8 @@ class GerritCommand(BackendCommand):
         group.add_argument("--max-reviews",  dest="max_reviews",
                            type=int, default=MAX_REVIEWS,
                            help="Max number of reviews per ssh query.")
+        group.add_argument("--blacklist-reviews",  dest="blacklist_reviews",
+                           type=str,
+                           help="Wrong reviews that must not be retrieved. Comma separated list.")
 
         return parser


### PR DESCRIPTION
Add --blacklist-reviews option for not retrieving wrong reviews from the remote gerrit server.

In Eclipse gerrit for example, right now:

https://git.eclipse.org/r/67778

returns and errors, and using the ssh API the server crash with a: 

fatal: internal server error

With this option, it can be avoided to download this reviews so the rest is retrieved correctly:

```
perceval -g gerrit --user XXXX --url git.eclipse.org --from-date '2015-12-29 17:00' --blacklist-reviews '67778'
```