### PR TITLE
[mediawiki] Use generic numeric format in datetime object

### DIFF
--- a/perceval/backends/mediawiki.py
+++ b/perceval/backends/mediawiki.py
@@ -428,7 +428,7 @@ class MediaWikiClient:
     def get_pages_from_allrevisions(self, namespaces, from_date=None, arvcontinue=None):
 
         if from_date:
-            from_date_str = from_date.isoformat()
+            from_date_str = from_date.strftime("%Y-%m-%d %H:%M:%S")
 
         params = {
             "action":"query",

--- a/perceval/backends/mediawiki.py
+++ b/perceval/backends/mediawiki.py
@@ -428,7 +428,10 @@ class MediaWikiClient:
     def get_pages_from_allrevisions(self, namespaces, from_date=None, arvcontinue=None):
 
         if from_date:
-            from_date_str = from_date.strftime("%Y-%m-%d %H:%M:%S")
+            if from_date.tzinfo != dateutil.tz.tzutc():
+                raise ValueError("Datetime is not in UTC timezone")
+
+            from_date_str = from_date.strftime("%Y-%m-%dT%H:%M:%SZ")
 
         params = {
             "action":"query",


### PR DESCRIPTION
This PR fixes #54  

As @crisbal reported, isoformat() method from datetime library is not supported by Mediawiki API (http://meta.wikitolearn.org/api.php).

I've changed it to a numeric generic format and it worked as expected.

