### PR TITLE
Add support for creating Pypi packages

### DIFF
--- a/docs/howto_doc.rst
+++ b/docs/howto_doc.rst
@@ -31,6 +31,7 @@ If there are changes in the list of modules
 ::
 
    cd docs
+   mkdir ../percevalsphinx-apidoc
    sphinx-apidoc --force -d 4 -o . ../percevalsphinx-apidoc --force -d 4 -o . ../perceval
    make html
 

--- a/docs/howto_pkg.rst
+++ b/docs/howto_pkg.rst
@@ -1,0 +1,85 @@
+.. _howto_pkg:
+
+How to produce Pypi packages
+============================
+
+These are instructions for producing packages of this module for Pypi.
+The first step is to produce pip packages. Then, they may be uploaded to Pypi.
+
+How to produce packages for pip
+-------------------------------
+
+For producing packages suitable for installation with pip, just follow these
+instructions:
+
+* Install the wheel Python module, if you want to create a wheel for a package.
+This is recommended, but not needed if you only intend to create a source code
+package.
+
+::
+
+  pip install wheel
+
+* If you don't have it installed, install support for pandoc, both at the
+operating system level (the Pandoc package) and at the python level
+(the pypandoc Python module). This is really not required, but is needed
+to convert the README.md file to reStructuredText, which is the format that
+Pypi seems to like. The apt-get command below works in Debian, Ubuntu, and
+other Debian derivatives, substitute by the installation command for your
+operating system.
+
+::
+
+  sudo apt-get install pandoc
+  pip install pypandoc
+
+* In the root directory for this source code (the root of the cloned git
+repository, for example) create the packages. First command below is for
+creating a source code package, second is for creating a wheel for your
+environment.
+
+::
+
+  python3 setup.py bdist_wheel
+  python setup.py sdist
+
+That's it. Your packages (source code and wheel) are now in the dist directory.
+
+How to upload packages to Pypi
+------------------------------
+
+* First, upload pacakges to the test Pypi repository, to check that everything
+is in working condition:
+
+::
+
+  python setup.py register -r pypitestpython setup.py register -r pypitest
+  python setup.py sdist upload -r pypitest
+  python setup.py bdist_wheel upload -r pypitest
+
+Now, you can check that the package is working by installing it in a clean
+virtual environment. For example, using pyvenv:
+
+::
+
+  pyvenv test-perceval
+  source test-perceval/bin/activate
+  pip install -i https://testpypi.python.org/pypi perceval
+
+Warning: since the test Pypi repository includes only some packages, it is
+very likely that some dependencies have to be installed from the live Pypi
+repository.
+
+More details about the test Pypi repository in the `Python wiki
+<https://wiki.python.org/moin/TestPyPI>`_.
+
+* Then, upload to the live Pypi repository, and you're done:
+
+::
+
+  python setup.py register -r pypitestpython setup.py register -r pypi
+  python setup.py sdist upload -r pypi
+  python setup.py bdist_wheel upload -r pypi
+
+The complete instructions can be found at `How to submit a package to PyPI
+<http://peterdowns.com/posts/first-time-with-pypi.html>`_.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,6 +11,7 @@ Contents:
    perceval
    contributing.rst
    howto_doc.rst
+   howto_pkg.rst
 
 Indices and tables
 ==================

--- a/perceval/_version.py
+++ b/perceval/_version.py
@@ -1,1 +1,2 @@
-__version__ = "0.2.0"
+# Versions compliant with PEP 440 https://www.python.org/dev/peps/pep-0440
+__version__ = "0.3.0a4"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[metadata]
+description-file = README.md

--- a/setup.py
+++ b/setup.py
@@ -21,18 +21,52 @@
 #     Santiago Dueñas <sduenas@bitergia.com>
 #
 
+# To use a consistent encoding
+import codecs
+from os import path
 import re
 
-from distutils.core import setup
+# Always prefer setuptools over distutils
+from setuptools import setup
 
+here = path.abspath(path.dirname(__file__))
+readme_md = path.join(here, 'README.md')
+version_py = path.join(here, 'perceval', '_version.py')
 
-with open('perceval/_version.py', 'r', encoding='utf-8') as fd:
+# Pypi wants the description to be in reStrcuturedText, but
+# we have it in Markdown. So, let's convert formats.
+# Set up thinkgs so that if pypandoc is not installed, it
+# just issues a warning.
+try:
+    import pypandoc
+    long_description = pypandoc.convert(readme_md, 'rst')
+except (IOError, ImportError):
+    print("Warning: pypandoc module not found, or pandoc not installed. " \
+            + "Using md instead of rst")
+    with codecs.open(readme_md, encoding='utf-8') as f:
+        long_description = f.read()
+
+with codecs.open(version_py, 'r', encoding='utf-8') as fd:
     version = re.search(r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]',
                         fd.read(), re.MULTILINE).group(1)
 
 setup(name="perceval",
+      description="Fetch data from software repositories",
+      long_description=long_description,
+      url="https://github.com/grimoirelab/perceval",
       version=version,
       author="Bitergia",
       author_email="sduenas@bitergia.com",
+      license="GPLv3",
+      classifiers=[
+        'Development Status :: 5 - Production/Stable',
+        'Intended Audience :: Developers',
+        'Topic :: Software Development',
+        'License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)',
+        'Programming Language :: Python :: 3'
+      ],
+      keywords="development repositories analytics git github bugzilla jira jenkins",
       packages=['perceval', 'perceval.backends'],
-      scripts=["bin/perceval"])
+      install_requires=['python-dateutil>=2.0.0', 'requests>=2.7.0', 'beautifulsoup4>=4.3.2'],
+      scripts=["bin/perceval"]
+      )


### PR DESCRIPTION
Changes to setup.py for creating packages suitable to be uploaded to Pypi.
Version bumped to 0.3.0a1 (Alpha 1 to 0.3.0) to have a base version number compatible with PEP 440 to start with. (then bumped to Alpha 4, after some tests on the test Pypi archive).
Documentation to create the pacakges in docs/howto_pkg.rst.
Fix minor issue in docs/howto_doc.rst.