### PR TITLE
[mediawiki] Use pages API by default for MediaWiki >= 1.27

### DIFF
--- a/perceval/backends/mediawiki.py
+++ b/perceval/backends/mediawiki.py
@@ -134,6 +134,7 @@ class MediaWiki(Backend):
         cache_items = self.cache.retrieve()
 
         pages_dicts = ['allrevisions','allpages','recentchanges']
+        pages_done = []  # pages already retrieved in reviews API
 
         # pages -> revisions
         for items in cache_items:
@@ -142,6 +143,11 @@ class MediaWiki(Backend):
                 if pages_dict in data_json['query']:
                     pages_json = data_json['query'][pages_dict]
                     for page in pages_json:
+                        if self.reviews_api:
+                            if page['pageid'] in pages_done:
+                                # The page was already returned for previous revisions
+                                continue
+                            pages_done.append(page['pageid'])
                         page_reviews = self.__build_page_reviews(page, json.loads(next(cache_items)))
                         if not page_reviews:
                             continue

--- a/tests/test_mediawiki.py
+++ b/tests/test_mediawiki.py
@@ -282,8 +282,8 @@ class TestMediaWikiBackendCache(unittest.TestCase):
         pages_1 = [page for page in mediawiki.fetch(reviews_api=reviews_api)]
         cached_pages = [page for page in mediawiki.fetch_from_cache()]
         if version == "1.28" and reviews_api:
-            # Only unique pages are returned in this version
-            self.assertEqual(len(cached_pages), 2)
+            # 2 unique pages x2 caches
+            self.assertEqual(len(cached_pages), 4)
         elif version == "1.23" or not reviews_api:
             # 2 pages per each of the 5 name spaces, x2 caches
             self.assertEqual(len(cached_pages), 10*2)


### PR DESCRIPTION
The use of the allrevisions API can be force using the new param --reviews-api when MediaWiki >= 1.27.

Updated tests for this new scenario.