### PR TITLE
Add MANIFEST.in to avoid problems when building sdist package.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include README.md


### PR DESCRIPTION
Whe building an sdist package, and pandoc was not available,
the rst version of README.md cannot be created. In this case,
README.md should be added to the package, but it was not.