### PR TITLE
[remo2] Change ReMo API URL for v2 to its final location: /api/remo/v1/

### DIFF
--- a/perceval/backends/remo2.py
+++ b/perceval/backends/remo2.py
@@ -217,7 +217,7 @@ class ReMoClient:
 
     FIRST_PAGE = 1  # Initial page in ReMo API
     ITEMS_PER_PAGE = 20 # Items per page in ReMo API
-    API_PATH = '/api/beta'
+    API_PATH = '/api/remo/v1'
 
     def __init__(self, url):
         self.url = url
@@ -272,7 +272,7 @@ class ReMoClient:
             if not next_uri:
                 more = False
             else:
-                # https://reps.mozilla.org/api/beta/events/?page=269
+                # https://reps.mozilla.org/remo/api/remo/v1/events/?page=269
                 page = next_uri.split("page=")[1]
 
 

--- a/tests/data/remo_activities.json
+++ b/tests/data/remo_activities.json
@@ -3,7 +3,7 @@
       "first_name":"Vaibhav",
       "last_name":"Bajaj",
       "display_name":"vabajaj",
-      "_url":"https://reps.mozilla.org/api/beta/users/1976/"
+      "_url":"https://reps.mozilla.org/api/remo/v1/users/1976/"
    },
    "activity":"Organized an Event",
    "initiative":"MozActivate",
@@ -18,7 +18,7 @@
       "first_name":"Ankit",
       "last_name":"Gadgil",
       "display_name":"ankitgadgil",
-      "_url":"https://reps.mozilla.org/api/beta/users/325/"
+      "_url":"https://reps.mozilla.org/api/remo/v1/users/325/"
    },
    "location":"Bhopal, Madhya Pradesh, India",
    "longitude":77.4043393126,
@@ -28,7 +28,7 @@
    "passive_report":true,
    "event":{  
       "name":"MozVR Camp Bhopal",
-      "_url":"https://reps.mozilla.org/api/beta/events/5936/"
+      "_url":"https://reps.mozilla.org/api/remo/v1/events/5936/"
    },
    "remo_url":"https://reps.mozilla.org/u/vabajaj/r/2016/November/5/40846/"
 }

--- a/tests/data/remo_activities_page_1_2.json
+++ b/tests/data/remo_activities_page_1_2.json
@@ -1,86 +1,86 @@
 {
     "count": 38481,
-    "next": "http://example.com/api/beta/activities/?format=json&page=2",
+    "next": "http://example.com/api/remo/v1/activities/?format=json&page=2",
     "previous": null,
     "results": [
         {
-            "_url": "http://example.com/api/beta/activities/40822/",
+            "_url": "http://example.com/api/remo/v1/activities/40822/",
             "activity": "Attended an Event"
         },
         {
-            "_url": "http://example.com/api/beta/activities/40803/",
+            "_url": "http://example.com/api/remo/v1/activities/40803/",
             "activity": "Organized an Event"
         },
         {
-            "_url": "http://example.com/api/beta/activities/40804/",
+            "_url": "http://example.com/api/remo/v1/activities/40804/",
             "activity": "Attended an Event"
         },
         {
-            "_url": "http://example.com/api/beta/activities/37059/",
+            "_url": "http://example.com/api/remo/v1/activities/37059/",
             "activity": "Organized an Event"
         },
         {
-            "_url": "http://example.com/api/beta/activities/37060/",
+            "_url": "http://example.com/api/remo/v1/activities/37060/",
             "activity": "Attended an Event"
         },
         {
-            "_url": "http://example.com/api/beta/activities/40701/",
+            "_url": "http://example.com/api/remo/v1/activities/40701/",
             "activity": "Attended an Event"
         },
         {
-            "_url": "http://example.com/api/beta/activities/40332/",
+            "_url": "http://example.com/api/remo/v1/activities/40332/",
             "activity": "Organized an Event"
         },
         {
-            "_url": "http://example.com/api/beta/activities/40333/",
+            "_url": "http://example.com/api/remo/v1/activities/40333/",
             "activity": "Attended an Event"
         },
         {
-            "_url": "http://example.com/api/beta/activities/40588/",
+            "_url": "http://example.com/api/remo/v1/activities/40588/",
             "activity": "Organized an Event"
         },
         {
-            "_url": "http://example.com/api/beta/activities/40589/",
+            "_url": "http://example.com/api/remo/v1/activities/40589/",
             "activity": "Attended an Event"
         },
         {
-            "_url": "http://example.com/api/beta/activities/38219/",
+            "_url": "http://example.com/api/remo/v1/activities/38219/",
             "activity": "Organized an Event"
         },
         {
-            "_url": "http://example.com/api/beta/activities/38220/",
+            "_url": "http://example.com/api/remo/v1/activities/38220/",
             "activity": "Attended an Event"
         },
         {
-            "_url": "http://example.com/api/beta/activities/40662/",
+            "_url": "http://example.com/api/remo/v1/activities/40662/",
             "activity": "Attended an Event"
         },
         {
-            "_url": "http://example.com/api/beta/activities/40659/",
+            "_url": "http://example.com/api/remo/v1/activities/40659/",
             "activity": "Attended an Event"
         },
         {
-            "_url": "http://example.com/api/beta/activities/38936/",
+            "_url": "http://example.com/api/remo/v1/activities/38936/",
             "activity": "Attended an Event"
         },
         {
-            "_url": "http://example.com/api/beta/activities/40719/",
+            "_url": "http://example.com/api/remo/v1/activities/40719/",
             "activity": "Organized an Event"
         },
         {
-            "_url": "http://example.com/api/beta/activities/40720/",
+            "_url": "http://example.com/api/remo/v1/activities/40720/",
             "activity": "Attended an Event"
         },
         {
-            "_url": "http://example.com/api/beta/activities/40846/",
+            "_url": "http://example.com/api/remo/v1/activities/40846/",
             "activity": "Organized an Event"
         },
         {
-            "_url": "http://example.com/api/beta/activities/40847/",
+            "_url": "http://example.com/api/remo/v1/activities/40847/",
             "activity": "Attended an Event"
         },
         {
-            "_url": "http://example.com/api/beta/activities/40834/",
+            "_url": "http://example.com/api/remo/v1/activities/40834/",
             "activity": "Organized an Event"
         }
     ]

--- a/tests/data/remo_activities_page_2_2.json
+++ b/tests/data/remo_activities_page_2_2.json
@@ -1,86 +1,86 @@
 {
     "count": 38481,
     "next": null,
-    "previous": "http://example.com/api/beta/activities/?format=json",
+    "previous": "http://example.com/api/remo/v1/activities/?format=json",
     "results": [
         {
-            "_url": "http://example.com/api/beta/activities/40835/",
+            "_url": "http://example.com/api/remo/v1/activities/40835/",
             "activity": "Attended an Event"
         },
         {
-            "_url": "http://example.com/api/beta/activities/40820/",
+            "_url": "http://example.com/api/remo/v1/activities/40820/",
             "activity": "Organized an Event"
         },
         {
-            "_url": "http://example.com/api/beta/activities/40821/",
+            "_url": "http://example.com/api/remo/v1/activities/40821/",
             "activity": "Attended an Event"
         },
         {
-            "_url": "http://example.com/api/beta/activities/40581/",
+            "_url": "http://example.com/api/remo/v1/activities/40581/",
             "activity": "Organized an Event"
         },
         {
-            "_url": "http://example.com/api/beta/activities/40582/",
+            "_url": "http://example.com/api/remo/v1/activities/40582/",
             "activity": "Attended an Event"
         },
         {
-            "_url": "http://example.com/api/beta/activities/37813/",
+            "_url": "http://example.com/api/remo/v1/activities/37813/",
             "activity": "Organized an Event"
         },
         {
-            "_url": "http://example.com/api/beta/activities/37814/",
+            "_url": "http://example.com/api/remo/v1/activities/37814/",
             "activity": "Attended an Event"
         },
         {
-            "_url": "http://example.com/api/beta/activities/40292/",
+            "_url": "http://example.com/api/remo/v1/activities/40292/",
             "activity": "Organized an Event"
         },
         {
-            "_url": "http://example.com/api/beta/activities/40293/",
+            "_url": "http://example.com/api/remo/v1/activities/40293/",
             "activity": "Attended an Event"
         },
         {
-            "_url": "http://example.com/api/beta/activities/40272/",
+            "_url": "http://example.com/api/remo/v1/activities/40272/",
             "activity": "Organized an Event"
         },
         {
-            "_url": "http://example.com/api/beta/activities/40273/",
+            "_url": "http://example.com/api/remo/v1/activities/40273/",
             "activity": "Attended an Event"
         },
         {
-            "_url": "http://example.com/api/beta/activities/37068/",
+            "_url": "http://example.com/api/remo/v1/activities/37068/",
             "activity": "Attended an Event"
         },
         {
-            "_url": "http://example.com/api/beta/activities/37067/",
+            "_url": "http://example.com/api/remo/v1/activities/37067/",
             "activity": "Organized an Event"
         },
         {
-            "_url": "http://example.com/api/beta/activities/40760/",
+            "_url": "http://example.com/api/remo/v1/activities/40760/",
             "activity": "Organized an Event"
         },
         {
-            "_url": "http://example.com/api/beta/activities/40761/",
+            "_url": "http://example.com/api/remo/v1/activities/40761/",
             "activity": "Attended an Event"
         },
         {
-            "_url": "http://example.com/api/beta/activities/40602/",
+            "_url": "http://example.com/api/remo/v1/activities/40602/",
             "activity": "Organized an Event"
         },
         {
-            "_url": "http://example.com/api/beta/activities/40603/",
+            "_url": "http://example.com/api/remo/v1/activities/40603/",
             "activity": "Attended an Event"
         },
         {
-            "_url": "http://example.com/api/beta/activities/40348/",
+            "_url": "http://example.com/api/remo/v1/activities/40348/",
             "activity": "Organized an Event"
         },
         {
-            "_url": "http://example.com/api/beta/activities/40349/",
+            "_url": "http://example.com/api/remo/v1/activities/40349/",
             "activity": "Attended an Event"
         },
         {
-            "_url": "http://example.com/api/beta/activities/40021/",
+            "_url": "http://example.com/api/remo/v1/activities/40021/",
             "activity": "Organized an Event"
         }
     ]

--- a/tests/data/remo_events.json
+++ b/tests/data/remo_events.json
@@ -13,7 +13,7 @@
       "first_name":"Irayani",
       "last_name":"Queencyputri",
       "display_name":"Rara",
-      "_url":"https://reps.mozilla.org/api/beta/users/180/"
+      "_url":"https://reps.mozilla.org/api/remo/v1/users/180/"
    },
    "external_link":"http://www.festivalkomputer.com/2012/index.php#makassar",
    "initiative":null,

--- a/tests/data/remo_events_page_1_2.json
+++ b/tests/data/remo_events_page_1_2.json
@@ -1,86 +1,86 @@
 {
     "count": 5375,
-    "next": "http://example.com/api/beta/events/?format=json&page=2",
+    "next": "http://example.com/api/remo/v1/events/?format=json&page=2",
     "previous": null,
     "results": [
         {
-            "_url": "http://example.com/api/beta/events/132/",
+            "_url": "http://example.com/api/remo/v1/events/132/",
             "name": "Festival Komputer Indonesia 2012 - Makassar"
         },
         {
-            "_url": "http://example.com/api/beta/events/327/",
+            "_url": "http://example.com/api/remo/v1/events/327/",
             "name": "MozFR 2012"
         },
         {
-            "_url": "http://example.com/api/beta/events/129/",
+            "_url": "http://example.com/api/remo/v1/events/129/",
             "name": "Blogilicious 2012 Madura"
         },
         {
-            "_url": "http://example.com/api/beta/events/403/",
+            "_url": "http://example.com/api/remo/v1/events/403/",
             "name": "mozfestpune"
         },
         {
-            "_url": "http://example.com/api/beta/events/208/",
+            "_url": "http://example.com/api/remo/v1/events/208/",
             "name": "Mozparty @ Anthiyur"
         },
         {
-            "_url": "http://example.com/api/beta/events/130/",
+            "_url": "http://example.com/api/remo/v1/events/130/",
             "name": "Blogilicious 2012 Solo"
         },
         {
-            "_url": "http://example.com/api/beta/events/22/",
+            "_url": "http://example.com/api/remo/v1/events/22/",
             "name": "1st Mozcoffee Sprint l10n in Zamboanga "
         },
         {
-            "_url": "http://example.com/api/beta/events/26/",
+            "_url": "http://example.com/api/remo/v1/events/26/",
             "name": "Summer Code Party: \u00e5\u00a4\u008f\u00e6\u2014\u00a5\u00e7\u0161\u201e Web \u00e6\u00a8\u201a\u00e5\u0153\u2019 (Pop Up)"
         },
         {
-            "_url": "http://example.com/api/beta/events/10/",
+            "_url": "http://example.com/api/remo/v1/events/10/",
             "name": "Webmakers make Popcorn"
         },
         {
-            "_url": "http://example.com/api/beta/events/9/",
+            "_url": "http://example.com/api/remo/v1/events/9/",
             "name": "August Penguin 2012"
         },
         {
-            "_url": "http://example.com/api/beta/events/27/",
+            "_url": "http://example.com/api/remo/v1/events/27/",
             "name": "Code Rush Subtitle Translation"
         },
         {
-            "_url": "http://example.com/api/beta/events/18/",
+            "_url": "http://example.com/api/remo/v1/events/18/",
             "name": "Presentation of Firefox in Fulah "
         },
         {
-            "_url": "http://example.com/api/beta/events/1/",
+            "_url": "http://example.com/api/remo/v1/events/1/",
             "name": "Mozgr Sumo Localization Sprint"
         },
         {
-            "_url": "http://example.com/api/beta/events/13/",
+            "_url": "http://example.com/api/remo/v1/events/13/",
             "name": "Nuevas Tecnolog\u00c3\u00adas Aplicadas"
         },
         {
-            "_url": "http://example.com/api/beta/events/37/",
+            "_url": "http://example.com/api/remo/v1/events/37/",
             "name": "MozCamp at DMIT, Bhartiya Vidya Bhavan, New Delhi"
         },
         {
-            "_url": "http://example.com/api/beta/events/43/",
+            "_url": "http://example.com/api/remo/v1/events/43/",
             "name": "MozClub at SICSR"
         },
         {
-            "_url": "http://example.com/api/beta/events/12/",
+            "_url": "http://example.com/api/remo/v1/events/12/",
             "name": "Mozilla Iftar"
         },
         {
-            "_url": "http://example.com/api/beta/events/2/",
+            "_url": "http://example.com/api/remo/v1/events/2/",
             "name": "Mozilla Iftar"
         },
         {
-            "_url": "http://example.com/api/beta/events/14/",
+            "_url": "http://example.com/api/remo/v1/events/14/",
             "name": "Mura Menti Napok"
         },
         {
-            "_url": "http://example.com/api/beta/events/5/",
+            "_url": "http://example.com/api/remo/v1/events/5/",
             "name": "COSCUP 2012"
         }
     ]

--- a/tests/data/remo_events_page_2_2.json
+++ b/tests/data/remo_events_page_2_2.json
@@ -1,86 +1,86 @@
 {
     "count": 5375,
     "next": null,
-    "previous": "http://example.com/api/beta/events/?format=json",
+    "previous": "http://example.com/api/remo/v1/events/?format=json",
     "results": [
         {
-            "_url": "http://example.com/api/beta/events/7/",
+            "_url": "http://example.com/api/remo/v1/events/7/",
             "name": "Kite show - Kalima extremo"
         },
         {
-            "_url": "http://example.com/api/beta/events/66/",
+            "_url": "http://example.com/api/remo/v1/events/66/",
             "name": "PHL Summer Code Party 2"
         },
         {
-            "_url": "http://example.com/api/beta/events/11/",
+            "_url": "http://example.com/api/remo/v1/events/11/",
             "name": "Mozilla Philippines Community HTML5 & Firefox OS (B2G) Roadshow"
         },
         {
-            "_url": "http://example.com/api/beta/events/207/",
+            "_url": "http://example.com/api/remo/v1/events/207/",
             "name": "Mozparty with a demo on using \"Firefox for Android\" @ Univercell , Perundurai"
         },
         {
-            "_url": "http://example.com/api/beta/events/78/",
+            "_url": "http://example.com/api/remo/v1/events/78/",
             "name": "SUNY Albany - Welcome to Campus!"
         },
         {
-            "_url": "http://example.com/api/beta/events/40/",
+            "_url": "http://example.com/api/remo/v1/events/40/",
             "name": "FUDCon LATAM 2012"
         },
         {
-            "_url": "http://example.com/api/beta/events/82/",
+            "_url": "http://example.com/api/remo/v1/events/82/",
             "name": "JCI birthday 27 old"
         },
         {
-            "_url": "http://example.com/api/beta/events/91/",
+            "_url": "http://example.com/api/remo/v1/events/91/",
             "name": "Open Data Mx"
         },
         {
-            "_url": "http://example.com/api/beta/events/46/",
+            "_url": "http://example.com/api/remo/v1/events/46/",
             "name": "The Developer Conference"
         },
         {
-            "_url": "http://example.com/api/beta/events/77/",
+            "_url": "http://example.com/api/remo/v1/events/77/",
             "name": "MozCaf\u00c3\u00a9 Algiers"
         },
         {
-            "_url": "http://example.com/api/beta/events/89/",
+            "_url": "http://example.com/api/remo/v1/events/89/",
             "name": "MozCoffee Delhi/NCR"
         },
         {
-            "_url": "http://example.com/api/beta/events/88/",
+            "_url": "http://example.com/api/remo/v1/events/88/",
             "name": "Mozilla Summer Code Party, BVPMOSC, Delhi"
         },
         {
-            "_url": "http://example.com/api/beta/events/34/",
+            "_url": "http://example.com/api/remo/v1/events/34/",
             "name": "Moz Interaction"
         },
         {
-            "_url": "http://example.com/api/beta/events/85/",
+            "_url": "http://example.com/api/remo/v1/events/85/",
             "name": "Facebook Developers World HACK"
         },
         {
-            "_url": "http://example.com/api/beta/events/50/",
+            "_url": "http://example.com/api/remo/v1/events/50/",
             "name": "MDN Docs Sprint"
         },
         {
-            "_url": "http://example.com/api/beta/events/67/",
+            "_url": "http://example.com/api/remo/v1/events/67/",
             "name": "MozKopdarSUB - August 2012"
         },
         {
-            "_url": "http://example.com/api/beta/events/69/",
+            "_url": "http://example.com/api/remo/v1/events/69/",
             "name": "Mozilla Firefox the best option"
         },
         {
-            "_url": "http://example.com/api/beta/events/123/",
+            "_url": "http://example.com/api/remo/v1/events/123/",
             "name": "Blogilicious 2012 Maros"
         },
         {
-            "_url": "http://example.com/api/beta/events/68/",
+            "_url": "http://example.com/api/remo/v1/events/68/",
             "name": "Braderie de Lille 2012"
         },
         {
-            "_url": "http://example.com/api/beta/events/31/",
+            "_url": "http://example.com/api/remo/v1/events/31/",
             "name": "Mozilla Urdu Localization Sprint"
         }
     ]

--- a/tests/data/remo_users.json
+++ b/tests/data/remo_users.json
@@ -91,7 +91,7 @@
       "first_name":"Robert",
       "last_name":"Reyes",
       "display_name":"bobreyes",
-      "_url":"https://reps.mozilla.org/api/beta/users/37/"
+      "_url":"https://reps.mozilla.org/api/remo/v1/users/37/"
    },
    "mozillians_profile_url":"https://mozillians.org/en-US/u/aaroncajes/",
    "timezone":"",

--- a/tests/data/remo_users_page_1_2.json
+++ b/tests/data/remo_users_page_1_2.json
@@ -1,124 +1,124 @@
 {
     "count": 336,
-    "next": "http://example.com/api/beta/users/?format=json&page=2",
+    "next": "http://example.com/api/remo/v1/users/?format=json&page=2",
     "previous": null,
     "results": [
         {
-            "_url": "http://example.com/api/beta/users/8/",
+            "_url": "http://example.com/api/remo/v1/users/8/",
             "display_name": "aaroncajes",
             "first_name": "Aaron",
             "last_name": "Cajes"
         },
         {
-            "_url": "http://example.com/api/beta/users/15/",
+            "_url": "http://example.com/api/remo/v1/users/15/",
             "display_name": "ahsan_net",
             "first_name": "Mashkawat",
             "last_name": "Ahsan"
         },
         {
-            "_url": "http://example.com/api/beta/users/18/",
+            "_url": "http://example.com/api/remo/v1/users/18/",
             "display_name": "alex_lakatos",
             "first_name": "Alex",
             "last_name": "Lakatos"
         },
         {
-            "_url": "http://example.com/api/beta/users/26/",
+            "_url": "http://example.com/api/remo/v1/users/26/",
             "display_name": "anupkumarmishra29",
             "first_name": "Anup Kumar",
             "last_name": "Mishra"
         },
         {
-            "_url": "http://example.com/api/beta/users/27/",
+            "_url": "http://example.com/api/remo/v1/users/27/",
             "display_name": "ardian",
             "first_name": "Ardian",
             "last_name": "Haxha"
         },
         {
-            "_url": "http://example.com/api/beta/users/31/",
+            "_url": "http://example.com/api/remo/v1/users/31/",
             "display_name": "ashickur_noor",
             "first_name": "Ashickur",
             "last_name": "Rahman"
         },
         {
-            "_url": "http://example.com/api/beta/users/33/",
+            "_url": "http://example.com/api/remo/v1/users/33/",
             "display_name": "belutz",
             "first_name": "Andi",
             "last_name": "Darmawan"
         },
         {
-            "_url": "http://example.com/api/beta/users/35/",
+            "_url": "http://example.com/api/remo/v1/users/35/",
             "display_name": "benoit_leseul",
             "first_name": "Benoit",
             "last_name": "Leseul"
         },
         {
-            "_url": "http://example.com/api/beta/users/37/",
+            "_url": "http://example.com/api/remo/v1/users/37/",
             "display_name": "bobreyes",
             "first_name": "Robert",
             "last_name": "Reyes"
         },
         {
-            "_url": "http://example.com/api/beta/users/44/",
+            "_url": "http://example.com/api/remo/v1/users/44/",
             "display_name": "benalichahreddine",
             "first_name": "Ben Ali",
             "last_name": "Chahreddine"
         },
         {
-            "_url": "http://example.com/api/beta/users/50/",
+            "_url": "http://example.com/api/remo/v1/users/50/",
             "display_name": "cstipkovic",
             "first_name": "Clauber",
             "last_name": "Stipkovic"
         },
         {
-            "_url": "http://example.com/api/beta/users/54/",
+            "_url": "http://example.com/api/remo/v1/users/54/",
             "display_name": "danyjavierb",
             "first_name": "Dany Javier",
             "last_name": "Bautista"
         },
         {
-            "_url": "http://example.com/api/beta/users/55/",
+            "_url": "http://example.com/api/remo/v1/users/55/",
             "display_name": "daviddagb2",
             "first_name": "David",
             "last_name": "Gonzalez Blanchard"
         },
         {
-            "_url": "http://example.com/api/beta/users/57/",
+            "_url": "http://example.com/api/remo/v1/users/57/",
             "display_name": "deimidis",
             "first_name": "Guillermo",
             "last_name": "Movia"
         },
         {
-            "_url": "http://example.com/api/beta/users/62/",
+            "_url": "http://example.com/api/remo/v1/users/62/",
             "display_name": "ebolinaga",
             "first_name": "Erick",
             "last_name": "Leon Bolinaga"
         },
         {
-            "_url": "http://example.com/api/beta/users/66/",
+            "_url": "http://example.com/api/remo/v1/users/66/",
             "display_name": "nino_vranesic",
             "first_name": "Nino",
             "last_name": "Vranesic"
         },
         {
-            "_url": "http://example.com/api/beta/users/73/",
+            "_url": "http://example.com/api/remo/v1/users/73/",
             "display_name": "Faten",
             "first_name": "Faten",
             "last_name": "Ben Thabet"
         },
         {
-            "_url": "http://example.com/api/beta/users/74/",
+            "_url": "http://example.com/api/remo/v1/users/74/",
             "display_name": "fauzanalfi",
             "first_name": "Fauzan Alfi",
             "last_name": "Agirachman"
         },
         {
-            "_url": "http://example.com/api/beta/users/75/",
+            "_url": "http://example.com/api/remo/v1/users/75/",
             "display_name": "fayetandog",
             "first_name": "Faye",
             "last_name": "Tandog"
         },
         {
-            "_url": "http://example.com/api/beta/users/81/",
+            "_url": "http://example.com/api/remo/v1/users/81/",
             "display_name": "fredy",
             "first_name": "Alfredos Panagiotis",
             "last_name": "Damkalis"

--- a/tests/data/remo_users_page_2_2.json
+++ b/tests/data/remo_users_page_2_2.json
@@ -1,124 +1,124 @@
 {
     "count": 336,
     "next": null,
-    "previous": "http://example.com/api/beta/users/?format=json",
+    "previous": "http://example.com/api/remo/v1/users/?format=json",
     "results": [
         {
-            "_url": "http://example.com/api/beta/users/85/",
+            "_url": "http://example.com/api/remo/v1/users/85/",
             "display_name": "galaxyk",
             "first_name": "Galaxy",
             "last_name": "Kadiyala"
         },
         {
-            "_url": "http://example.com/api/beta/users/101/",
+            "_url": "http://example.com/api/remo/v1/users/101/",
             "display_name": "hmitsch",
             "first_name": "Henrik",
             "last_name": "Mitsch"
         },
         {
-            "_url": "http://example.com/api/beta/users/109/",
+            "_url": "http://example.com/api/remo/v1/users/109/",
             "display_name": "ioana_chiorean",
             "first_name": "Stefania Ioana",
             "last_name": "Chiorean"
         },
         {
-            "_url": "http://example.com/api/beta/users/115/",
+            "_url": "http://example.com/api/remo/v1/users/115/",
             "display_name": "jeferduran",
             "first_name": "Jefferson",
             "last_name": "Duran"
         },
         {
-            "_url": "http://example.com/api/beta/users/118/",
+            "_url": "http://example.com/api/remo/v1/users/118/",
             "display_name": "jesanchez",
             "first_name": "Juan Eladio",
             "last_name": "Sanchez Rosas"
         },
         {
-            "_url": "http://example.com/api/beta/users/119/",
+            "_url": "http://example.com/api/remo/v1/users/119/",
             "display_name": "jlapitan",
             "first_name": "Joell",
             "last_name": "Lapitan"
         },
         {
-            "_url": "http://example.com/api/beta/users/122/",
+            "_url": "http://example.com/api/remo/v1/users/122/",
             "display_name": "jsan4christ",
             "first_name": "San",
             "last_name": "Emmanuel James"
         },
         {
-            "_url": "http://example.com/api/beta/users/124/",
+            "_url": "http://example.com/api/remo/v1/users/124/",
             "display_name": "junior",
             "first_name": "Jose Junior",
             "last_name": "Villagomez Melgar"
         },
         {
-            "_url": "http://example.com/api/beta/users/127/",
+            "_url": "http://example.com/api/remo/v1/users/127/",
             "display_name": "kami911",
             "first_name": "Kalman",
             "last_name": "Szalai"
         },
         {
-            "_url": "http://example.com/api/beta/users/132/",
+            "_url": "http://example.com/api/remo/v1/users/132/",
             "display_name": "kjdomanog",
             "first_name": "Kemuel Joseph",
             "last_name": "Domanog"
         },
         {
-            "_url": "http://example.com/api/beta/users/133/",
+            "_url": "http://example.com/api/remo/v1/users/133/",
             "display_name": "kjventura",
             "first_name": "Kevin John",
             "last_name": "Ventura"
         },
         {
-            "_url": "http://example.com/api/beta/users/138/",
+            "_url": "http://example.com/api/remo/v1/users/138/",
             "display_name": "lennoazevedo",
             "first_name": "Lenno",
             "last_name": "Azevedo"
         },
         {
-            "_url": "http://example.com/api/beta/users/144/",
+            "_url": "http://example.com/api/remo/v1/users/144/",
             "display_name": "maedca",
             "first_name": "Manuel",
             "last_name": "Camacho"
         },
         {
-            "_url": "http://example.com/api/beta/users/147/",
+            "_url": "http://example.com/api/remo/v1/users/147/",
             "display_name": "mak",
             "first_name": "Khan",
             "last_name": "Mahay"
         },
         {
-            "_url": "http://example.com/api/beta/users/148/",
+            "_url": "http://example.com/api/remo/v1/users/148/",
             "display_name": "mozillamarcia_knous",
             "first_name": "Marcia",
             "last_name": "Knous"
         },
         {
-            "_url": "http://example.com/api/beta/users/155/",
+            "_url": "http://example.com/api/remo/v1/users/155/",
             "display_name": "melek",
             "first_name": "Melek",
             "last_name": "Jebnoun"
         },
         {
-            "_url": "http://example.com/api/beta/users/156/",
+            "_url": "http://example.com/api/remo/v1/users/156/",
             "display_name": "mmkmou",
             "first_name": "Mouhamadou Moustapha",
             "last_name": "CAMARA"
         },
         {
-            "_url": "http://example.com/api/beta/users/163/",
+            "_url": "http://example.com/api/remo/v1/users/163/",
             "display_name": "nex",
             "first_name": "Hugo",
             "last_name": "Acosta"
         },
         {
-            "_url": "http://example.com/api/beta/users/168/",
+            "_url": "http://example.com/api/remo/v1/users/168/",
             "display_name": "odinmojica",
             "first_name": "Odin",
             "last_name": "Mojica"
         },
         {
-            "_url": "http://example.com/api/beta/users/178/",
+            "_url": "http://example.com/api/remo/v1/users/178/",
             "display_name": "rami223",
             "first_name": "Rami",
             "last_name": "Khader"

--- a/tests/test_remo2.py
+++ b/tests/test_remo2.py
@@ -41,7 +41,7 @@ from perceval.backends.remo2 import (
 
 
 MOZILLA_REPS_SERVER_URL = 'http://example.com'
-MOZILLA_REPS_API = MOZILLA_REPS_SERVER_URL + '/api/beta'
+MOZILLA_REPS_API = MOZILLA_REPS_SERVER_URL + '/api/remo/v1'
 
 MOZILLA_REPS_CATEGORIES = ['events', 'activities', 'users']
 
@@ -351,7 +351,7 @@ class TestReMoClient(unittest.TestCase):
         req = HTTPServer.requests_http[-1]
         self.assertEqual(response, body)
         self.assertEqual(req.method, 'GET')
-        self.assertEqual(req.path, '/api/beta/events/?page=1')
+        self.assertEqual(req.path, '/api/remo/v1/events/?page=1')
         # Check request params
         expected = {
                     'page' : ['1']
@@ -371,7 +371,7 @@ class TestReMoClient(unittest.TestCase):
         req = HTTPServer.requests_http[-1]
         self.assertEqual(response, body)
         self.assertEqual(req.method, 'GET')
-        self.assertEqual(req.path, '/api/beta/events/?page=1')
+        self.assertEqual(req.path, '/api/remo/v1/events/?page=1')
         # Check request params
         expected = {
                     'page' : ['1']


### PR DESCRIPTION
Probably the API is not called anymore as v2 so as soon as we discuss and fix all issues between the old v1 and v2 (new v1), remo2 will be renamed to remo and the old remo will be removed.