### PR TITLE
[remo2] Add remo2 to the list of supported backends in help and README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ are:
     phabricator      Fetch tasks from a Phabricator site
     pipermail        Fetch messages from a Pipermail archiver
     redmine          Fetch issues from a Redmine server
-    remo             Fetch events and people from a ReMo site
+    remo             Fetch events and people from a ReMo site (old API v1)
+    remo2            Fetch events and people from a ReMo site (API v1)
     stackexchange    Fetch questions from StackExchange sites
     supybot          Fetch messages from Supybot log files
     telegram         Fetch messages from the Telegram server

--- a/bin/perceval
+++ b/bin/perceval
@@ -56,7 +56,8 @@ are:
     phabricator      Fetch tasks from a Phabricator site
     pipermail        Fetch messages from a Pipermail archiver
     redmine          Fetch issues from a Redmine server
-    remo             Fetch events and people from a ReMo site
+    remo             Fetch events and people from a ReMo site (old API v1)
+    remo2            Fetch events and people from a ReMo site (API v1)
     stackexchange    Fetch questions from StackExchange sites
     supybot          Fetch messages from Supybot log files
     telegram         Fetch messages from the Telegram server

--- a/perceval/backends/remo2.py
+++ b/perceval/backends/remo2.py
@@ -65,7 +65,7 @@ class ReMo(Backend):
     this class an URL may be provided. If not, https://reps.mozilla.org
     will be used. The origin of the data will be set to this URL.
 
-    It uses v2 API to get events, people and activities data.
+    It uses API v1 final to get events, people and activities data.
 
     :param url: ReMo URL
     :param tag: label used to mark the data
@@ -251,7 +251,7 @@ class ReMoClient:
         :param params: dict with the HTTP parameters needed to run
             the given command
         """
-        logger.debug("ReMo client calls APIv2: %s params: %s",
+        logger.debug("ReMo client calls API v1 final: %s params: %s",
                      uri, str(params))
 
         req = requests.get(uri, params=params)


### PR DESCRIPTION
Change API v2 to API v1 final as the name of the API used.
