### PR TITLE
fixed FSF address

### DIFF
--- a/bin/perceval
+++ b/bin/perceval
@@ -15,7 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA. 
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>

--- a/perceval/__init__.py
+++ b/perceval/__init__.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA. 
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>

--- a/perceval/backend.py
+++ b/perceval/backend.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA. 
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>

--- a/perceval/backends/__init__.py
+++ b/perceval/backends/__init__.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA. 
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>

--- a/perceval/backends/core/askbot.py
+++ b/perceval/backends/core/askbot.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA. 
 #
 # Authors:
 #     Alberto Martín <alberto.martin@bitergia.com>

--- a/perceval/backends/core/bugzilla.py
+++ b/perceval/backends/core/bugzilla.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA. 
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>

--- a/perceval/backends/core/bugzillarest.py
+++ b/perceval/backends/core/bugzillarest.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA. 
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>

--- a/perceval/backends/core/confluence.py
+++ b/perceval/backends/core/confluence.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA. 
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>

--- a/perceval/backends/core/discourse.py
+++ b/perceval/backends/core/discourse.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA. 
 #
 # Authors:
 #    Santiago Dueñas <sduenas@bitergia.com>

--- a/perceval/backends/core/gerrit.py
+++ b/perceval/backends/core/gerrit.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA. 
 #
 # Authors:
 #     Alvaro del Castillo San Felix <acs@bitergia.com>

--- a/perceval/backends/core/git.py
+++ b/perceval/backends/core/git.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA. 
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>

--- a/perceval/backends/core/github.py
+++ b/perceval/backends/core/github.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA. 
 #
 # Authors:
 #     Alvaro del Castillo San Felix <acs@bitergia.com>

--- a/perceval/backends/core/gmane.py
+++ b/perceval/backends/core/gmane.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA. 
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>

--- a/perceval/backends/core/jenkins.py
+++ b/perceval/backends/core/jenkins.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA. 
 #
 # Authors:
 #     Alvaro del Castillo <acs@bitergia.com>

--- a/perceval/backends/core/jira.py
+++ b/perceval/backends/core/jira.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA. 
 #
 # Authors:
 #     Alberto Martín <alberto.martin@bitergia.com>

--- a/perceval/backends/core/mbox.py
+++ b/perceval/backends/core/mbox.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA. 
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>

--- a/perceval/backends/core/mediawiki.py
+++ b/perceval/backends/core/mediawiki.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA. 
 #
 # Authors:
 #     Alvaro del Castillo <acs@bitergia.com>

--- a/perceval/backends/core/meetup.py
+++ b/perceval/backends/core/meetup.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA. 
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>

--- a/perceval/backends/core/phabricator.py
+++ b/perceval/backends/core/phabricator.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA. 
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>

--- a/perceval/backends/core/pipermail.py
+++ b/perceval/backends/core/pipermail.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA. 
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>

--- a/perceval/backends/core/redmine.py
+++ b/perceval/backends/core/redmine.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA. 
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>

--- a/perceval/backends/core/rss.py
+++ b/perceval/backends/core/rss.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA. 
 #
 # Authors:
 #     Alvaro del Castillo <acs@bitergia.com>

--- a/perceval/backends/core/stackexchange.py
+++ b/perceval/backends/core/stackexchange.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA. 
 #
 # Authors:
 #     Alberto Martín <alberto.martin@bitergia.com>

--- a/perceval/backends/core/supybot.py
+++ b/perceval/backends/core/supybot.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA. 
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>

--- a/perceval/backends/core/telegram.py
+++ b/perceval/backends/core/telegram.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA. 
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>

--- a/perceval/cache.py
+++ b/perceval/cache.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA. 
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>

--- a/perceval/errors.py
+++ b/perceval/errors.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA. 
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>

--- a/perceval/utils.py
+++ b/perceval/utils.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA. 
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA. 
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -15,7 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA. 
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>

--- a/tests/test_askbot.py
+++ b/tests/test_askbot.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA. 
 #
 # Authors:
 #     Alberto Martín <alberto.martin@bitergia.com>

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -15,7 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA. 
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>

--- a/tests/test_bugzilla.py
+++ b/tests/test_bugzilla.py
@@ -15,7 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA. 
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>

--- a/tests/test_bugzillarest.py
+++ b/tests/test_bugzillarest.py
@@ -15,7 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA. 
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -15,7 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA. 
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>

--- a/tests/test_confluence.py
+++ b/tests/test_confluence.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA. 
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>

--- a/tests/test_discourse.py
+++ b/tests/test_discourse.py
@@ -15,7 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA. 
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -15,7 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA. 
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -15,7 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA. 
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -15,7 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA. 
 #
 # Authors:
 #     Quan Zhou <quan@bitergia.com>

--- a/tests/test_gmane.py
+++ b/tests/test_gmane.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA. 
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>

--- a/tests/test_jenkins.py
+++ b/tests/test_jenkins.py
@@ -15,7 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA. 
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -15,7 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA. 
 #
 # Authors:
 #     Alberto Martín <alberto.martin@bitergia.com>

--- a/tests/test_mbox.py
+++ b/tests/test_mbox.py
@@ -15,7 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA. 
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>

--- a/tests/test_mediawiki.py
+++ b/tests/test_mediawiki.py
@@ -15,7 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA. 
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>

--- a/tests/test_meetup.py
+++ b/tests/test_meetup.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA. 
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>

--- a/tests/test_phabricator.py
+++ b/tests/test_phabricator.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA. 
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>

--- a/tests/test_pipermail.py
+++ b/tests/test_pipermail.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA. 
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>

--- a/tests/test_redmine.py
+++ b/tests/test_redmine.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA. 
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>

--- a/tests/test_rss.py
+++ b/tests/test_rss.py
@@ -15,7 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA. 
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>

--- a/tests/test_stackexchange.py
+++ b/tests/test_stackexchange.py
@@ -15,7 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA. 
 #
 # Authors:
 #     Quan Zhou <quan@bitergia.com>

--- a/tests/test_supybot.py
+++ b/tests/test_supybot.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA. 
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>

--- a/tests/test_telegram.py
+++ b/tests/test_telegram.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA. 
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -15,7 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA. 
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>


### PR DESCRIPTION
Fixed the address of the Free Software Foundation in all occurrences. See here for the right address:
http://www.fsf.org/about/contact/