### PR TITLE
[jenkins] Change the URL from which jobs are collected to retrieve all jobs

### DIFF
--- a/perceval/backends/core/jenkins.py
+++ b/perceval/backends/core/jenkins.py
@@ -51,7 +51,7 @@ class Jenkins(Backend):
     :param cache: cache object to store raw data
     :param blacklist_jobs: exclude the jobs of this list while fetching
     """
-    version = '0.5.1'
+    version = '0.5.2'
 
     def __init__(self, url, tag=None, cache=None, blacklist_jobs=None):
         origin = url
@@ -199,7 +199,7 @@ class JenkinsClient:
     def get_jobs(self):
         """ Retrieve all jobs
         """
-        url_jenkins = self.url + "/view/All/api/json"
+        url_jenkins = self.url + "/api/json"
 
         req = requests.get(url_jenkins)
         req.raise_for_status()

--- a/perceval/backends/core/jenkins.py
+++ b/perceval/backends/core/jenkins.py
@@ -199,7 +199,7 @@ class JenkinsClient:
     def get_jobs(self):
         """ Retrieve all jobs
         """
-        url_jenkins = self.url + "/api/json"
+        url_jenkins = urljoin(self.url, "/api/json")
 
         req = requests.get(url_jenkins)
         req.raise_for_status()

--- a/tests/test_jenkins.py
+++ b/tests/test_jenkins.py
@@ -45,7 +45,7 @@ from perceval.backends.core.jenkins import (Jenkins,
 
 
 JENKINS_SERVER_URL = 'http://example.com/ci'
-JENKINS_JOBS_URL = JENKINS_SERVER_URL + '/view/All/api/json'
+JENKINS_JOBS_URL = JENKINS_SERVER_URL + '/api/json'
 JENKINS_JOB_BUILDS_1 = 'apex-build-brahmaputra'
 JENKINS_JOB_BUILDS_2 = 'apex-build-master'
 JENKINS_JOB_BUILDS_500_ERROR = '500-error-job'


### PR DESCRIPTION
Right now we are collecting the jobs from the URL:

<jenkins_url>/view/All/api/json

but this view does not always exists, and it could not contain all the jobs.

Using directly:

<jenkins_url>/api/json

we get all the jobs from the jenkins server.