### PR TITLE
[mediawiki] Change log level to warning when a revision is not found in a page

### DIFF
--- a/perceval/backends/core/mediawiki.py
+++ b/perceval/backends/core/mediawiki.py
@@ -371,8 +371,8 @@ class MediaWiki(Backend):
                 page["revisions"] = reviews_json['revisions']
                 page['update'] = self.__get_max_date(page['revisions'])
         else:
-            logger.error("Revisions not found in %s", reviews["query"]["pages"])
-            logger.error("for page: %s", page)
+            logger.warning("Revisions not found in %s", reviews["query"]["pages"])
+            logger.warning("for page: %s", page)
             page = None
         return page
 


### PR DESCRIPTION
When a revision is not found in a page, change the log level from error to warning because it is not an error.

For example, for MediaWiki we have some logs like:

```
2017-02-27 13:00:45,181 - perceval.backends.core.mediawiki - ERROR - Revisions not found in {'-1': {'missing': '', 'title': 'Telefonliste', 'ns': 0}}
2017-02-27 13:00:45,182 - perceval.backends.core.mediawiki - ERROR - for page: {'old_revid': 0, 'pageid': 665362, 'revid': 0, 'timestamp': '2017-02-27T11:08:59Z', 'revisions': None, 'update': None, 'rcid': 2901417, 'type': 'log', 'title': 'Telefonliste', 'ns': 0}
...
2017-02-27 13:01:34,508 - perceval.backends.core.mediawiki - ERROR - Revisions not found in {'-1': {'missing': '', 'title': 'Test page 123', 'ns': 0}}
2017-02-27 13:01:34,510 - perceval.backends.core.mediawiki - ERROR - for page: {'old_revid': 0, 'pageid': 665347, 'revid': 0, 'timestamp': '2017-02-27T08:35:26Z', 'revisions': None, 'update': None, 'rcid': 2901265, 'type': 'log', 'title': 'Test page 123', 'ns': 0}
2017-02-27 13:01:35,121 - perceval.backends.core.mediawiki - ERROR - Revisions not found in {'-1': {'missing': '', 'title': 'Test page jhfbksndvl', 'ns': 0}}
2017-02-27 13:01:35,131 - perceval.backends.core.mediawiki - ERROR - for page: {'old_revid': 0, 'pageid': 665349, 'revid': 0, 'timestamp': '2017-02-27T08:34:58Z', 'revisions': None, 'update': None, 'rcid': 2901263, 'type': 'log', 'title': 'Test page jhfbksndvl', 'ns': 0}
2017-02-27 13:01:36,628 - perceval.backends.core.mediawiki - ERROR - Revisions not found in {'-1': {'missing': '', 'title': 'Test page 12345', 'ns': 0}}
2017-02-27 13:01:36,628 - perceval.backends.core.mediawiki - ERROR - for page: {'old_revid': 0, 'pageid': 665353, 'revid': 0, 'timestamp': '2017-02-27T08:34:10Z', 'revisions': None, 'update': None, 'rcid': 2901231, 'type': 'log', 'title': 'Test page 12345', 'ns': 0}
2017-02-27 13:01:37,865 - perceval.backends.core.mediawiki - ERROR - Revisions not found in {'-1': {'missing': '', 'title': 'Test page 123456', 'ns': 0}}
2017-02-27 13:01:37,866 - perceval.backends.core.mediawiki - ERROR - for page: {'old_revid': 0, 'pageid': 665354, 'revid': 0, 'timestamp': '2017-02-27T08:33:11Z', 'revisions': None, 'update': None, 'rcid': 2901227, 'type': 'log', 'title': 'Test page 123456', 'ns': 0}
```

and these reviews seems to be test data with a strange "-1" id. So this is clearly just a warning and not a real error.