### PR TITLE
[rss] Add User-Agent header in RSS request so wordpress.com blog sites return the data

### DIFF
--- a/perceval/backends/core/rss.py
+++ b/perceval/backends/core/rss.py
@@ -166,7 +166,8 @@ class RSSClient:
     def get_entries(self):
         """ Retrieve all entries from a RSS feed"""
 
-        req = requests.get(self.url)
+        # wordpress.com blogs need a User-Agent header
+        req = requests.get(self.url, headers={'User-Agent':'perceval'})
         req.raise_for_status()
         return req.text
 


### PR DESCRIPTION
In wordpress.com if the User-Agent header is not included, a forbidden (403) response is received.
Fix #128. Solution proposed by albertinisg!