### PR TITLE
[discourse] Do not process topics with last_posted_at = None

### DIFF
--- a/perceval/backends/core/discourse.py
+++ b/perceval/backends/core/discourse.py
@@ -234,6 +234,9 @@ class Discourse(Backend):
 
         for topic in topics_page['topic_list']['topics']:
             topic_id = topic['id']
+            if topic['last_posted_at'] is None:
+                logger.warning("Topic %s with last_posted_at null. Ignoring it.", topic['title'])
+                continue
             updated_at = str_to_datetime(topic['last_posted_at'])
             pinned = topic['pinned']
             topics_ids.append((topic_id, updated_at, pinned))

--- a/tests/data/discourse_topics_last_posted_at_null.json
+++ b/tests/data/discourse_topics_last_posted_at_null.json
@@ -1,0 +1,98 @@
+{
+    "topic_list": {
+        "can_create_topic": false,
+        "draft": null,
+        "draft_key": "new_topic",
+        "draft_sequence": null,
+        "per_page": 30,
+        "topics": [
+            {
+                "archetype": "regular",
+                "archived": false,
+                "bookmarked": null,
+                "bumped": true,
+                "bumped_at": "2017-08-14T19:46:41.794Z",
+                "category_id": 200,
+                "closed": false,
+                "created_at": "2017-08-14T19:42:20.000Z",
+                "fancy_title": "PAGESHOTS",
+                "featured_link": null,
+                "has_accepted_answer": false,
+                "has_summary": false,
+                "highest_post_number": 1,
+                "id": 1148,
+                "image_url": null,
+                "last_posted_at": null,
+                "last_poster_username": "Bryce_Willingham",
+                "like_count": 0,
+                "liked": null,
+                "pinned": false,
+                "pinned_globally": false,
+                "posters": [
+                    {
+                        "description": "Original Poster, Most Recent Poster",
+                        "extras": "latest single",
+                        "primary_group_id": null,
+                        "user_id": 9172
+                    }
+                ],
+                "posts_count": 1,
+                "reply_count": 0,
+                "slug": "pageshots",
+                "title": "PAGESHOTS",
+                "unpinned": null,
+                "unseen": false,
+                "views": 44,
+                "visible": true
+            },
+            {
+                "archetype": "regular",
+                "archived": false,
+                "bookmarked": null,
+                "bumped": true,
+                "bumped_at": "2016-05-25T00:06:10.909Z",
+                "category_id": 14,
+                "closed": false,
+                "created_at": "2016-05-24T10:00:45.506Z",
+                "fancy_title": "Specify per-item service catalogue approval type",
+                "has_accepted_answer": false,
+                "has_summary": false,
+                "highest_post_number": 4,
+                "id": 1149,
+                "image_url": null,
+                "last_posted_at": "2016-05-25T00:06:10.909Z",
+                "last_poster_username": "jockey10",
+                "like_count": 0,
+                "liked": null,
+                "pinned": false,
+                "pinned_globally": false,
+                "posters": [
+                    {
+                        "description": "Original Poster, Most Recent Poster",
+                        "extras": "latest",
+                        "user_id": 644
+                    },
+                    {
+                        "description": "Frequent Poster",
+                        "extras": null,
+                        "user_id": 105
+                    },
+                    {
+                        "description": "Frequent Poster",
+                        "extras": null,
+                        "user_id": 23
+                    }
+                ],
+                "posts_count": 4,
+                "reply_count": 1,
+                "slug": "specify-per-item-service-catalogue-approval-type",
+                "tags": null,
+                "title": "Specify per-item service catalogue approval type",
+                "unpinned": null,
+                "unseen": false,
+                "views": 30,
+                "visible": true
+            }
+    	]
+    }
+}


### PR DESCRIPTION
This error is described at 

https://github.com/grimoirelab/perceval/issues/150

and it can be reproduced with:

`perceval discourse https://discourse.mozilla.org/`

This PR fixes it.