### PR TITLE
__version__ is not part of the module perceval

### DIFF
--- a/bin/perceval
+++ b/bin/perceval
@@ -79,7 +79,7 @@ PERCEVAL_EPILOG_MSG = \
 """Run '%(prog)s <backend> --help' to get information about a specific backend."""
 
 PERCEVAL_VERSION_MSG = \
-"""%(prog)s """  + perceval.__version__
+"""%(prog)s """  + perceval._version.__version__
 
 
 # Logging formats


### PR DESCRIPTION
The perceval bin script is failing on my system, because it cannot find __version__ in the perceval module. This change fixes it, perceval can be used as a command line utility again