### PR TITLE
[github] Fix abuse rate limit error

### DIFF
--- a/perceval/backends/core/github.py
+++ b/perceval/backends/core/github.py
@@ -609,8 +609,7 @@ class GitHubClient:
 
                 break
             except requests.exceptions.HTTPError as e:
-                if e.response.status_code == 403 \
-                        and "abuse detection mechanism" in json.loads(e.response.text)['message'].lower():
+                if e.response.status_code == 403 and 'Retry-After' in r.headers:
                     retry_seconds = int(r.headers['Retry-After'])
                     logger.warning("Abuse rate limit, the backend will sleep for %s seconds before starting again",
                                    retry_seconds)

--- a/tests/data/github/abuse_rate_limit
+++ b/tests/data/github/abuse_rate_limit
@@ -1,0 +1,4 @@
+{
+  "documentation_url": "https://developer.github.com/v3/#abuse-rate-limits",
+  "message": "You have triggered an abuse detection mechanism. Please wait a few minutes before you try again."
+}

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -875,6 +875,26 @@ class TestGitHubClient(unittest.TestCase):
         self.assertEqual(httpretty.last_request().headers["Authorization"], "token aaa")
 
     @httpretty.activate
+    def test_abuse_rate_limit(self):
+        """Test when Abuse Rate Limit exception is thrown"""
+
+        abuse_rate_limit = read_file('data/github/abuse_rate_limit')
+
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_ISSUES_URL,
+                               body=abuse_rate_limit, status=403,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '5',
+                                   'X-RateLimit-Reset': '5',
+                                   'Retry-After': '1'
+                               })
+
+        client = GitHubClient("zhquan_example", "repo", "aaa", None)
+
+        with self.assertRaises(requests.exceptions.HTTPError):
+            _ = [issues for issues in client.issues()]
+
+    @httpretty.activate
     def test_get_empty_issues(self):
         """ Test when issue is empty API call """
 


### PR DESCRIPTION
This pull request extends the github backend to deal with [abuse rate limit exceptions](https://developer.github.com/v3/#staying-within-the-rate-limit).
In a nutshell, if an abuse rate limit exception is triggered when querying the API, the backend sleeps for the number of seconds reported in the **retry-after** header field. This process is repeated at most 5 times (**MAX_RETRIES** in GitHubClient), before the backend stops and returns an error.