### PR TITLE
[git] Fix flake8 error

### DIFF
--- a/perceval/backends/core/git.py
+++ b/perceval/backends/core/git.py
@@ -640,8 +640,8 @@ class GitParser:
 
     def __parse_data_list(self, data, sep=' '):
         if data:
-            l = data.strip().split(sep)
-            return [e.strip() for e in l]
+            lst = data.strip().split(sep)
+            return [e.strip() for e in lst]
         else:
             return []
 


### PR DESCRIPTION
Fix for flake8 error: 
- ./perceval/backends/core/git.py:643:13: E741 ambiguous variable name 'l'
This error is probably related to a new release of flake8 (2017-10-23)