### PR TITLE
[gerrit] Fix flake8 errors

### DIFF
--- a/perceval/backends/core/gerrit.py
+++ b/perceval/backends/core/gerrit.py
@@ -182,7 +182,7 @@ class Gerrit(Backend):
             review = reviews.pop(0)
             try:
                 last_item += 1
-            except:
+            except Exception:
                 pass  # last_item is a string in old gerrits
             updated = review['lastUpdated']
             if updated <= from_ut:
@@ -350,7 +350,7 @@ class GerritClient():
         try:
             mayor = int(m.group(1))
             minor = int(m.group(2))
-        except:
+        except Exception:
             cause = "Gerrit client could not determine the server version."
             raise BackendError(cause=cause)
 


### PR DESCRIPTION
Fix for flake8 errors:
- /perceval/backends/core/gerrit.py:185:13: E722 do not use bare except'
- ./perceval/backends/core/gerrit.py:353:9: E722 do not use bare except'
Those errors are probably related to a new release of flake8 (2017-10-23)