### PR TITLE
[git] Fix fetch-pack for HTTPs connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Run 'perceval <backend> --help' to get information about a specific backend.
 * python3-requests >= 2.7
 * python3-bs4 (beautifulsoup4) >= 4.3
 * python3-feedparser >= 5.1.3
+* python3-dulwich >= 0.18.5
 * grimoirelab-toolkit >= 0.1.0
 
 ## Installation

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ python-dateutil>=2.6.0
 requests>=2.7.0
 beautifulsoup4>=4.3.2
 feedparser>=5.1.3
+dulwich>=0.18.5
 -e git+https://github.com/grimoirelab/grimoirelab-toolkit/#egg=grimoirelab-toolkit

--- a/setup.py
+++ b/setup.py
@@ -80,6 +80,7 @@ setup(name="perceval",
           'requests>=2.7.0',
           'beautifulsoup4>=4.3.2',
           'feedparser>=5.1.3',
+          'dulwich>=0.18.5',
           'grimoirelab-toolkit>=0.1.1'
       ],
       scripts=[


### PR DESCRIPTION
The command 'fetch-pack' only works with the TCP (git://)
protocol unless '--stateless-rpc' flag is active, the caller
has established a connection with the server using HTTP
and a pipe to it.

Some Git servers do not let to talk to them using TCP
protocol, only using HTTP(s) on top of it.

To fix this issue, dulwich library has been used. It allows
to talk to Git repositories without calling git commands
directly. In this particular case, it is able to fetch
packs using any protocol.

This would be the first step to replace Git commands by
calls to a pure Python library.