### PR TITLE
[git] Limit the number of 'have' commits sent by fetch-pack

### DIFF
--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -91,7 +91,7 @@ class TestGitBackend(TestCaseGit):
             subprocess.check_call(['tar', '-xzf', tar_path, '-C', cls.tmp_repo_path])
 
             origin_path = os.path.join(cls.tmp_repo_path, repo_name)
-            subprocess.check_call(['git', 'clone', '-q', '--mirror', origin_path, repo_path],
+            subprocess.check_call(['git', 'clone', '-q', '--bare', origin_path, repo_path],
                                   stderr=fdout)
 
     @classmethod
@@ -1005,7 +1005,7 @@ class TestGitRepository(TestCaseGit):
             subprocess.check_call(['tar', '-xzf', tar_path, '-C', cls.tmp_repo_path])
 
             origin_path = os.path.join(cls.tmp_repo_path, repo_name)
-            subprocess.check_call(['git', 'clone', '-q', '--mirror', origin_path, repo_path],
+            subprocess.check_call(['git', 'clone', '-q', '--bare', origin_path, repo_path],
                                   stderr=fdout)
 
     @classmethod
@@ -1268,9 +1268,7 @@ class TestGitRepository(TestCaseGit):
         expected = [
             'refs/heads/lzp',
             'refs/heads/master',
-            'refs/heads/mybranch',
-            'refs/remotes/origin/HEAD',
-            'refs/remotes/origin/master'
+            'refs/heads/mybranch'
         ]
         refs = [ref for ref in discover_refs(new_path).keys()]
         refs.sort()
@@ -1288,9 +1286,7 @@ class TestGitRepository(TestCaseGit):
 
         expected = [
             'refs/heads/master',
-            'refs/heads/mybranch',
-            'refs/remotes/origin/HEAD',
-            'refs/remotes/origin/master'
+            'refs/heads/mybranch'
         ]
         refs = [ref for ref in discover_refs(new_path).keys()]
         refs.sort()


### PR DESCRIPTION
The current code sends, during the fetch-pack negotiation,
the hash for all the commits that the client has. This is not
needed. Only head hashes are usually needed by the server
to determine which objects needs to send back to the client.
In big repositories, this may hang the communication.

This commits adds a simple graph walker which only sends
the current hashes for each 'refs/heads/' or 'refs/tags/'
available in the client repository.

Backend version updated to 0.8.5.