### PR TITLE
[git] Fix error fetching latest items from empty repositories

### DIFF
--- a/perceval/backends/core/git.py
+++ b/perceval/backends/core/git.py
@@ -66,7 +66,7 @@ class Git(Backend):
     :raises RepositoryError: raised when there was an error cloning or
         updating the repository.
     """
-    version = '0.8.5'
+    version = '0.8.6'
 
     def __init__(self, uri, gitpath, tag=None, cache=None):
         origin = uri
@@ -110,14 +110,15 @@ class Git(Backend):
 
         :returns: a generator of commits
         """
-        if os.path.isfile(self.gitpath):
-            commits = self.__fetch_from_log()
-        else:
-            commits = self.__fetch_from_repo(from_date, branches,
-                                             latest_items)
-
         ncommits = 0
+
         try:
+            if os.path.isfile(self.gitpath):
+                commits = self.__fetch_from_log()
+            else:
+                commits = self.__fetch_from_repo(from_date, branches,
+                                                 latest_items)
+
             for commit in commits:
                 yield commit
                 ncommits += 1
@@ -1078,6 +1079,11 @@ class GitRepository:
             cmd_refs = ['git', 'ls-remote', '-h', '-t', 'origin']
             sep = '\t'
         else:
+            # Check first whether the local repo is empty;
+            # Running 'show-ref' in empty repos gives an error
+            if self.is_empty():
+                raise EmptyRepositoryError(repository=self.uri)
+
             cmd_refs = ['git', 'show-ref', '--heads', '--tags']
             sep = ' '
 

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -469,6 +469,24 @@ class TestGitBackend(TestCaseGit):
         shutil.rmtree(editable_path)
         shutil.rmtree(new_path)
 
+    def test_fetch_latest_items_from_empty_repository(self):
+        """Test whether it fetches no items from an empty repository"""
+
+        new_path = os.path.join(self.tmp_path, 'newgit')
+
+        git = Git(self.git_empty_path, new_path)
+
+        # First time, latest items are fetched using 'git log'
+        commits = [commit for commit in git.fetch(latest_items=True)]
+        self.assertListEqual(commits, [])
+
+        # Further times, latest items are fetched using 'git fetch-pack'
+        # and 'git show'
+        commits = [commit for commit in git.fetch(latest_items=True)]
+        self.assertListEqual(commits, [])
+
+        shutil.rmtree(new_path)
+
     def test_fetch_from_file(self):
         """Test whether commits are fetched from a Git log file"""
 
@@ -1294,6 +1312,18 @@ class TestGitRepository(TestCaseGit):
 
         # Cleanup
         shutil.rmtree(editable_path)
+        shutil.rmtree(new_path)
+
+    def test_sync_from_empty_repos(self):
+        """Test sync process on empty repositories"""
+
+        new_path = os.path.join(self.tmp_path, 'newgit')
+
+        repo = GitRepository.clone(self.git_empty_path, new_path)
+
+        with self.assertRaises(EmptyRepositoryError):
+            repo.sync()
+
         shutil.rmtree(new_path)
 
     def test_log(self):


### PR DESCRIPTION
The command 'show-ref' returns an error when is run in
empty repositories.

This patch checks whether the repository is empty before
checking the references, raising an exception on that case.

Backend version updated to 0.8.6.