### PR TITLE
[client] Add generic client

### DIFF
--- a/perceval/backends/core/askbot.py
+++ b/perceval/backends/core/askbot.py
@@ -35,10 +35,16 @@ from ...backend import (Backend,
                         BackendCommand,
                         BackendCommandArgumentParser,
                         metadata)
+from ...client import HttpClient
+from ...errors import HttpClientError
 from ...utils import DEFAULT_DATETIME
 
 
 logger = logging.getLogger(__name__)
+
+
+API_QUESTIONS = 'api/v1/questions/'
+HTML_QUESTION = 'question/'
 
 
 class Askbot(Backend):
@@ -51,7 +57,7 @@ class Askbot(Backend):
     :param url: Askbot site URL
     :param tag: label used to mark the data
     """
-    version = '0.2.4'
+    version = '0.3.0'
 
     def __init__(self, url, tag=None):
         origin = url
@@ -78,19 +84,10 @@ class Askbot(Backend):
 
         from_date = datetime_to_utc(from_date).timestamp()
 
-        npages = 1
-        next_request = True
+        questions_groups = self.client.get_api_questions(API_QUESTIONS)
+        for questions in questions_groups:
 
-        while next_request:
-            whole_page = self.client.get_api_questions(npages)
-            raw_questions = json.loads(whole_page)
-            questions = raw_questions['questions']
-            tpages = raw_questions['pages']
-
-            logger.debug("Fetching questions from '%s': page %s/%s",
-                         self.url, npages, tpages)
-
-            for question in questions:
+            for question in questions['questions']:
                 updated_at = int(question['last_activity_at'])
                 if updated_at > from_date:
                     html_question = self.__fetch_question(question)
@@ -103,19 +100,11 @@ class Askbot(Backend):
                     question.update(question_obj)
                     yield question
 
-            if npages == tpages:
-                next_request = False
-
-            npages = npages + 1
-
     def __fetch_question(self, question):
         """Fetch an Askbot HTML question body.
-
         The method fetchs the HTML question retrieving the
         question body of the item question received
-
         :param question: item with the question itself
-
         :returns: a list of HTML page/s for the question
         """
 
@@ -236,7 +225,7 @@ class Askbot(Backend):
         return question_object
 
 
-class AskbotClient:
+class AskbotClient(HttpClient):
     """Askbot client.
 
     This class implements a simple client to retrieve distinct
@@ -247,8 +236,6 @@ class AskbotClient:
     :raises HTTPError: when an error occurs doing the request
     """
 
-    API_QUESTIONS = 'api/v1/questions/'
-    HTML_QUESTION = 'question/'
     ORDER_API = 'activity-asc'
     ORDER_HTML = 'votes'
     COMMENTS = 's/post_comments'
@@ -257,76 +244,97 @@ class AskbotClient:
     def __init__(self, base_url):
         self.base_url = base_url
         self._use_new_urls = True
+        super().__init__(self.base_url)
 
-    def get_api_questions(self, page=1):
-        """Retrieve a question page using the API.
+    def get_api_questions(self, path):
 
-        :param page: page to retrieve
-        """
-        path = self.API_QUESTIONS
-        params = {
-            'page': page,
-            'sort': self.ORDER_API
-        }
-        response = self.__call(path, params)
-        return response
+        npages = 1
+        next_request = True
+
+        path = urijoin(self.base_url, path)
+        while next_request:
+            try:
+                params = {
+                    'page': npages,
+                    'sort': self.ORDER_API
+                }
+
+                response = next(self.fetch(path, payload=params))
+
+                whole_page = response.text
+
+                raw_questions = json.loads(whole_page)
+                tpages = raw_questions['pages']
+
+                logger.debug("Fetching questions from '%s': page %s/%s",
+                             self.base_url, npages, tpages)
+
+                if npages == tpages:
+                    next_request = False
+
+                npages = npages + 1
+                yield raw_questions
+
+            except requests.exceptions.TooManyRedirects as e:
+                logger.warning("%s, data not retrieved for resource %s", e, path)
+                next_request = False
 
     def get_html_question(self, question_id, page=1):
         """Retrieve a raw HTML question and all it's information.
-
         :param question_id: question identifier
         :param page: page to retrieve
         """
-        path = urijoin(self.HTML_QUESTION, question_id)
+
+        path = urijoin(self.base_url, HTML_QUESTION, question_id)
+
         params = {
             'page': page,
             'sort': self.ORDER_HTML
         }
 
-        response = self.__call(path, params)
-        return response
+        response = next(self.fetch(path, payload=params))
+
+        if HttpClient.is_response(response):
+            return response.text
+        else:
+            cause = "Error during fetching html question not treated."
+            raise HttpClientError(cause=cause)
 
     def get_comments(self, post_id):
         """Retrieve a list of comments by a given id.
 
         :param object_id: object identifiere
         """
-        path = self.COMMENTS if self._use_new_urls else self.COMMENTS_OLD
+        path = urijoin(self.base_url, self.COMMENTS if self._use_new_urls else self.COMMENTS_OLD)
+
         params = {
             'post_id': post_id,
             'post_type': 'answer',
             'avatar_size': 0
         }
-        headers = {'X-Requested-With': 'XMLHttpRequest'}
 
-        try:
-            response = self.__call(path, params, headers)
-        except requests.exceptions.HTTPError as ex:
-            if ex.response.status_code == 404:
-                logger.debug("Comments URL did not work. Using old URL schema.")
-                self._use_new_urls = False
-                path = self.COMMENTS_OLD
-                response = self.__call(path, params, headers)
-            else:
-                raise ex
+        response = next(self.fetch(path, payload=params, headers=self.__build_headers()))
 
-        return response
+        if response == self.STOP:
+            self._use_new_urls = False
+            path = urijoin(self.base_url, self.COMMENTS_OLD)
+            response = next(self.fetch(path, payload=params, headers=self.__build_headers()))
 
-    def __call(self, path, params=None, headers=None):
-        """Retrieve all the questions.
+        if HttpClient.is_response(response):
+            return response.text
+        else:
+            cause = "Error during fetching comment not treated."
+            raise HttpClientError(cause=cause)
 
-        :param path: path of the url
-        :param params: dict with the HTTP parameters needed to run
-            the given command
-        :param headers: headers to use in the request
-        """
+    def __build_headers(self):
+        return {'X-Requested-With': 'XMLHttpRequest'}
 
-        url = urijoin(self.base_url, path)
-
-        req = requests.get(url, params=params, headers=headers)
-        req.raise_for_status()
-
-        return req.text
+    def handle_http_400_errors(self, error, retries=0, url=None, payload=None, headers=None):
+        if error.response.status_code == 404 and urijoin(self.base_url, self.COMMENTS) in url:
+            logger.debug("Comments URL did not work. Using old URL schema.")
+            return self.STOP
+        else:
+            raise error
 
 
 class AskbotParser:

--- a/perceval/client.py
+++ b/perceval/client.py
@@ -74,8 +74,8 @@ class HttpClient:
     def is_response(obj):
         return type(obj) == requests.Response
 
-    def init_api_token(self, path, params=None, headers=None):
-        response = self.__send_request(path, params, headers)
+    def init_api_token(self, path, params=None, headers=None, use_session=False, method=GET):
+        response = self.send_request(path, params, headers, use_session, method)
 
         self.rate_limit = int(response.headers[self.RATE_LIMIT_HEADER])
         self.rate_limit_reset_ts = int(response.headers[self.RATE_LIMIT_RESET_HEADER])

--- a/perceval/client.py
+++ b/perceval/client.py
@@ -113,6 +113,9 @@ class HttpClient:
             except requests.exceptions.ConnectTimeout as e:
                 error = e
                 time.sleep(self.default_sleep_time * retries)
+            except requests.exceptions.ConnectionError as e:
+                error = e
+                time.sleep(self.default_sleep_time * retries)
             except requests.exceptions.HTTPError as e:
                 if e.response.status_code >= 500:
                     if self.STOP == self.handle_http_500_errors(e, retries, url, payload, headers):

--- a/perceval/client.py
+++ b/perceval/client.py
@@ -93,10 +93,10 @@ class HttpClient:
         self.rate_limit = int(response.headers[self.RATE_LIMIT_HEADER])
         self.rate_limit_reset_ts = int(response.headers[self.RATE_LIMIT_RESET_HEADER])
 
-    def fetch(self, url, payload=None, headers=None, use_session=False, method=GET):
-        yield self._fetch(url, payload, headers, use_session, method)
+    def fetch(self, url, payload=None, headers=None, use_session=False, method=GET, stream=False):
+        yield self._fetch(url, payload, headers, use_session, method, stream)
 
-    def _fetch(self, url, payload=None, headers=None, use_session=False, method=GET):
+    def _fetch(self, url, payload=None, headers=None, use_session=False, method=GET, stream=False):
         retries = 0
 
         response = None
@@ -107,7 +107,7 @@ class HttpClient:
 
             try:
                 self.sleep_for_rate_limit()
-                response = self.send_request(url, payload, headers, use_session, method)
+                response = self.send_request(url, payload, headers, use_session, method, stream)
                 self.update_rate_limit(response)
                 break
             except requests.exceptions.ConnectTimeout as e:
@@ -159,28 +159,28 @@ class HttpClient:
             self.rate_limit = None
             self.rate_limit_reset_ts = None
 
-    def send_request(self, url, payload=None, headers=None, use_session=False, method=GET):
+    def send_request(self, url, payload=None, headers=None, use_session=False, method=GET, stream=False):
         if method == self.GET:
-            response = self.__send_get_request(url, payload, headers, use_session)
+            response = self.__send_get_request(url, payload, headers, use_session, stream)
         else:
-            response = self.__send_post_request(url, payload, headers, use_session)
+            response = self.__send_post_request(url, payload, headers, use_session, stream)
 
         response.raise_for_status()
 
         return response
 
-    def __send_get_request(self, url, payload=None, headers=None, use_session=False):
+    def __send_get_request(self, url, payload=None, headers=None, use_session=False, stream=False):
         if not use_session:
-            response = requests.get(url, params=payload, headers=headers)
+            response = requests.get(url, params=payload, headers=headers, stream=stream)
         else:
-            response = self.session.get(url, params=payload, headers=headers)
+            response = self.session.get(url, params=payload, headers=headers, stream=stream)
 
         return response
 
-    def __send_post_request(self, url, payload=None, headers=None, use_session=False):
+    def __send_post_request(self, url, payload=None, headers=None, use_session=False, stream=False):
         if not use_session:
-            response = requests.post(url, data=payload, headers=headers)
+            response = requests.post(url, data=payload, headers=headers, stream=stream)
         else:
-            response = self.session.post(url, data=payload, headers=headers)
+            response = self.session.post(url, data=payload, headers=headers, stream=stream)
 
         return response

--- a/perceval/client.py
+++ b/perceval/client.py
@@ -1,0 +1,153 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2017 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA.
+#
+# Authors:
+#     Valerio Cosentino <valcos@bitergia.com>
+#
+
+import logging
+import time
+
+import requests
+from .errors import RateLimitError
+
+logger = logging.getLogger(__name__)
+
+
+class HttpClient:
+    """Abstract class for HTTP clients.
+
+    Base class to query data sources.
+
+    Derivated classes have to implement `call`, `params`, `headers`
+    `pagination`, `has_retry` and `has_sleep` methods. Otherwise, `NotImplementedError`
+    exception will be raised.
+
+    To track which version of the client was used during the fetching
+    process, this class provides a `version` attribute that each client
+    may override.
+
+    :param has_rest: rest between calls
+    :param has_retry: retry calls in case of data source failures
+    :param has_pagination: client returns paginated items from the data source
+    """
+    version = '0.1'
+
+    MIN_RATE_LIMIT = 10
+
+    DEFAULT_SLEEP_TIME = 1
+    MAX_RETRIES = 5
+
+    RATE_LIMIT_HEADER = "X-RateLimit-Remaining"
+    RATE_LIMIT_RESET_HEADER = "X-RateLimit-Reset"
+
+    RETRY = "retry"
+    STOP = "stop"
+
+    def __init__(self, base_url, sleep_for_rate=False, min_rate_to_sleep=MIN_RATE_LIMIT,
+                 max_retries=MAX_RETRIES, default_sleep_time=DEFAULT_SLEEP_TIME):
+        self.base_url = base_url
+        self.rate_limit = None
+        self.rate_limit_reset_ts = None
+        self.sleep_for_rate = sleep_for_rate
+        self.min_rate_to_sleep = min_rate_to_sleep
+
+        self.max_retries = max_retries
+        self.default_sleep_time = default_sleep_time
+
+    @staticmethod
+    def is_response(obj):
+        return type(obj) == requests.Response
+
+    def init_api_token(self, path, params=None, headers=None):
+        response = self.__send_request(path, params, headers)
+
+        self.rate_limit = int(response.headers[self.RATE_LIMIT_HEADER])
+        self.rate_limit_reset_ts = int(response.headers[self.RATE_LIMIT_RESET_HEADER])
+
+    def fetch(self, url, params=None, headers=None):
+        yield self._fetch(url, params, headers)
+
+    def _fetch(self, url, params=None, headers=None):
+        retries = 0
+
+        response = None
+        error = None
+
+        while retries <= self.max_retries:
+            retries += 1
+
+            try:
+                self.sleep_for_rate_limit()
+                response = self.__send_request(url, params, headers)
+                self.update_rate_limit(response)
+                break
+            except requests.exceptions.ConnectTimeout as e:
+                error = e
+                time.sleep(self.default_sleep_time * retries)
+            except requests.exceptions.HTTPError as e:
+                if e.response.status_code >= 500:
+                    if self.STOP == self.handle_http_500_errors(e, retries, url, params, headers):
+                        response = self.STOP
+                        break
+                    error = e
+                if e.response.status_code >= 400:
+                    if self.STOP == self.handle_http_400_errors(e, retries, url, params, headers):
+                        response = self.STOP
+                        break
+                    error = e
+                else:
+                    error = e
+                    break
+
+        if error:
+            raise error
+
+        return response
+
+    def handle_http_500_errors(self, error, retries=0, url=None, params=None, headers=None):
+        time.sleep(self.default_sleep_time * retries)
+        return self.RETRY
+
+    def handle_http_400_errors(self, error, retries=0, url=None, params=None, headers=None):
+        return self.STOP
+
+    def sleep_for_rate_limit(self):
+        if self.rate_limit is not None and self.rate_limit <= self.min_rate_to_sleep:
+            seconds_to_reset = self.rate_limit_reset_ts - int(time.time()) + 1
+            cause = "Rate limit exhausted."
+            if self.sleep_for_rate:
+                logger.info("%s Waiting %i secs for rate limit reset.", cause, seconds_to_reset)
+                time.sleep(seconds_to_reset)
+            else:
+                raise RateLimitError(cause=cause, seconds_to_reset=seconds_to_reset)
+
+    def update_rate_limit(self, response):
+        if self.RATE_LIMIT_HEADER in response.headers:
+            self.rate_limit = int(response.headers[self.RATE_LIMIT_HEADER])
+            self.rate_limit_reset_ts = int(response.headers[self.RATE_LIMIT_RESET_HEADER])
+            logger.debug("Rate limit: %s", self.rate_limit)
+        else:
+            self.rate_limit = None
+            self.rate_limit_reset_ts = None
+
+    def __send_request(self, url, params=None, headers=None):
+        response = requests.get(url, params=params, headers=headers)
+        response.raise_for_status()
+
+        return response

--- a/perceval/client.py
+++ b/perceval/client.py
@@ -64,6 +64,7 @@ class HttpClient:
         self.base_url = base_url
         self.rate_limit = None
         self.rate_limit_reset_ts = None
+        self.session = None
         self.sleep_for_rate = sleep_for_rate
         self.min_rate_to_sleep = min_rate_to_sleep
 
@@ -73,6 +74,15 @@ class HttpClient:
     @staticmethod
     def is_response(obj):
         return type(obj) == requests.Response
+
+    def create_http_session(self, headers=None):
+        self.session = requests.Session()
+
+        if headers:
+            self.session.headers.update(headers)
+
+    def close_http_session(self):
+        self.session.close()
 
     def init_api_token(self, path, params=None, headers=None, use_session=False, method=GET):
         response = self.send_request(path, params, headers, use_session, method)

--- a/perceval/errors.py
+++ b/perceval/errors.py
@@ -49,6 +49,12 @@ class CacheError(BaseError):
     message = "%(cause)s"
 
 
+class HttpClientError(BaseError):
+    """Generic error for HTTP Cient"""
+
+    message = "%(cause)s"
+
+
 class RepositoryError(BaseError):
     """Generic error for repositories"""
 

--- a/tests/data/github/rate_limit
+++ b/tests/data/github/rate_limit
@@ -1,0 +1,24 @@
+{
+    "rate": {
+        "limit": 5000,
+        "remaining": 4990,
+        "reset": 1511195459
+    },
+    "resources": {
+        "core": {
+            "limit": 5000,
+            "remaining": 4990,
+            "reset": 1511195459
+        },
+        "graphql": {
+            "limit": 5000,
+            "remaining": 5000,
+            "reset": 1511195662
+        },
+        "search": {
+            "limit": 30,
+            "remaining": 30,
+            "reset": 1511192122
+        }
+    }
+}

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -29,6 +29,6 @@ import unittest
 if __name__ == '__main__':
 
     test_suite = unittest.TestLoader().discover(os.path.join(os.path.dirname(os.path.abspath(__file__)), "."),
-                                                pattern='test_hyperkitty.py')
+                                                pattern='test_jira.py')
     result = unittest.TextTestRunner(buffer=True).run(test_suite)
     sys.exit(not result.wasSuccessful())

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -29,6 +29,6 @@ import unittest
 if __name__ == '__main__':
 
     test_suite = unittest.TestLoader().discover(os.path.join(os.path.dirname(os.path.abspath(__file__)), "."),
-                                                pattern='test_confluence.py')
+                                                pattern='test_discourse.py')
     result = unittest.TextTestRunner(buffer=True).run(test_suite)
     sys.exit(not result.wasSuccessful())

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -29,6 +29,6 @@ import unittest
 if __name__ == '__main__':
 
     test_suite = unittest.TestLoader().discover(os.path.join(os.path.dirname(os.path.abspath(__file__)), "."),
-                                                pattern='test_*.py')
+                                                pattern='test_confluence.py')
     result = unittest.TextTestRunner(buffer=True).run(test_suite)
     sys.exit(not result.wasSuccessful())

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -29,6 +29,6 @@ import unittest
 if __name__ == '__main__':
 
     test_suite = unittest.TestLoader().discover(os.path.join(os.path.dirname(os.path.abspath(__file__)), "."),
-                                                pattern='test_discourse.py')
+                                                pattern='test_gmane.py')
     result = unittest.TextTestRunner(buffer=True).run(test_suite)
     sys.exit(not result.wasSuccessful())

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -29,6 +29,6 @@ import unittest
 if __name__ == '__main__':
 
     test_suite = unittest.TestLoader().discover(os.path.join(os.path.dirname(os.path.abspath(__file__)), "."),
-                                                pattern='test_jira.py')
+                                                pattern='test_launchpad.py')
     result = unittest.TextTestRunner(buffer=True).run(test_suite)
     sys.exit(not result.wasSuccessful())

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -29,6 +29,6 @@ import unittest
 if __name__ == '__main__':
 
     test_suite = unittest.TestLoader().discover(os.path.join(os.path.dirname(os.path.abspath(__file__)), "."),
-                                                pattern='test_launchpad.py')
+                                                pattern='test_*.py')
     result = unittest.TextTestRunner(buffer=True).run(test_suite)
     sys.exit(not result.wasSuccessful())

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -29,6 +29,6 @@ import unittest
 if __name__ == '__main__':
 
     test_suite = unittest.TestLoader().discover(os.path.join(os.path.dirname(os.path.abspath(__file__)), "."),
-                                                pattern='test_gmane.py')
+                                                pattern='test_hyperkitty.py')
     result = unittest.TextTestRunner(buffer=True).run(test_suite)
     sys.exit(not result.wasSuccessful())

--- a/tests/test_askbot.py
+++ b/tests/test_askbot.py
@@ -215,9 +215,8 @@ class TestAskbotClient(unittest.TestCase):
 
         client = AskbotClient(ASKBOT_URL)
 
-        result = client.get_api_questions(1)
-
-        self.assertEqual(result, body)
+        result = next(client.get_api_questions('api/v1/questions'))
+        self.assertEqual(result, json.loads(body))
 
         expected = {
             'page': ['1'],

--- a/tests/test_bugzilla.py
+++ b/tests/test_bugzilla.py
@@ -728,7 +728,7 @@ class TestBugzillaClient(unittest.TestCase):
 
         client = BugzillaClient(BUGZILLA_SERVER_URL)
         self.assertEqual(client.version, None)
-        self.assertIsInstance(client._session, requests.Session)
+        self.assertIsInstance(client.session, requests.Session)
 
     @httpretty.activate
     def test_init_auth(self):

--- a/tests/test_discourse.py
+++ b/tests/test_discourse.py
@@ -563,7 +563,7 @@ class TestDiscourseClient(unittest.TestCase):
         client = DiscourseClient(DISCOURSE_SERVER_URL,
                                  api_key='aaaa')
 
-        self.assertEqual(client.url, DISCOURSE_SERVER_URL)
+        self.assertEqual(client.base_url, DISCOURSE_SERVER_URL)
         self.assertEqual(client.api_key, 'aaaa')
 
     @httpretty.activate

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -49,6 +49,7 @@ from perceval.backends.core.github import (GitHub,
 
 
 GITHUB_API_URL = "https://api.github.com"
+GITHUB_RATE_LIMIT = GITHUB_API_URL + "/rate_limit"
 GITHUB_ISSUES_URL = GITHUB_API_URL + "/repos/zhquan_example/repo/issues"
 GITHUB_ISSUE_1_COMMENTS_URL = GITHUB_ISSUES_URL + "/1/comments"
 GITHUB_ISSUE_COMMENT_1_REACTION_URL = GITHUB_ISSUES_URL + "/comments/1/reactions"
@@ -61,6 +62,7 @@ GITHUB_COMMAND_URL = GITHUB_API_URL + "/command"
 
 GITHUB_ENTERPRISE_URL = "https://example.com"
 GITHUB_ENTERPRISE_API_URL = "https://example.com/api/v3"
+GITHUB_ENTREPRISE_RATE_LIMIT = GITHUB_ENTERPRISE_API_URL + "/rate_limit"
 GITHUB_ENTERPRISE_ISSUES_URL = GITHUB_ENTERPRISE_API_URL + "/repos/zhquan_example/repo/issues"
 GITHUB_ENTERPRISE_ISSUE_1_COMMENTS_URL = GITHUB_ENTERPRISE_ISSUES_URL + "/1/comments"
 GITHUB_ENTERPRISE_ISSUE_COMMENT_1_REACTION_URL = GITHUB_ENTERPRISE_ISSUES_URL + "/comments/1/reactions"
@@ -80,8 +82,19 @@ def read_file(filename, mode='r'):
 class TestGitHubBackend(unittest.TestCase):
     """ GitHub backend tests """
 
+    @httpretty.activate
     def test_initialization(self):
         """Test whether attributes are initializated"""
+
+        rate_limit = read_file('data/github/rate_limit')
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_RATE_LIMIT,
+                               body=rate_limit,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
 
         github = GitHub('zhquan_example', 'repo', 'aaa', tag='test')
 
@@ -123,6 +136,16 @@ class TestGitHubBackend(unittest.TestCase):
         orgs = read_file('data/github/github_orgs')
         comments = read_file('data/github/github_issue_comments_1')
         reactions = read_file('data/github/github_issue_comment_1_reactions')
+        rate_limit = read_file('data/github/rate_limit')
+
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_RATE_LIMIT,
+                               body=rate_limit,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
 
         httpretty.register_uri(httpretty.GET,
                                GITHUB_ISSUES_URL,
@@ -194,6 +217,16 @@ class TestGitHubBackend(unittest.TestCase):
         issue_2_comments = read_file('data/github/github_issue_comments_2')
         issue_comment_1_reactions = read_file('data/github/github_issue_comment_1_reactions')
         issue_comment_2_reactions = read_file('data/github/github_empty_request')
+        rate_limit = read_file('data/github/rate_limit')
+
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_RATE_LIMIT,
+                               body=rate_limit,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
 
         httpretty.register_uri(httpretty.GET,
                                GITHUB_ISSUES_URL,
@@ -292,6 +325,16 @@ class TestGitHubBackend(unittest.TestCase):
         orgs = read_file('data/github/github_orgs')
         comments = read_file('data/github/github_empty_request')
         expected = read_file('data/github/github_request_expected_zero_reactions')
+        rate_limit = read_file('data/github/rate_limit')
+
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_RATE_LIMIT,
+                               body=rate_limit,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
 
         httpretty.register_uri(httpretty.GET,
                                GITHUB_ISSUES_URL,
@@ -344,6 +387,16 @@ class TestGitHubBackend(unittest.TestCase):
         issue_2_comments = read_file('data/github/github_issue_comments_2')
         issue_comment_1_reactions = read_file('data/github/github_issue_comment_1_reactions')
         issue_comment_2_reactions = read_file('data/github/github_empty_request')
+        rate_limit = read_file('data/github/rate_limit')
+
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_ENTREPRISE_RATE_LIMIT,
+                               body=rate_limit,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
 
         httpretty.register_uri(httpretty.GET,
                                GITHUB_ENTERPRISE_ISSUES_URL,
@@ -410,6 +463,16 @@ class TestGitHubBackend(unittest.TestCase):
         comments = read_file('data/github/github_issue_comments_2')
         issue_reactions = read_file('data/github/github_issue_2_reactions')
         comment_reactions = read_file('data/github/github_empty_request')
+        rate_limit = read_file('data/github/rate_limit')
+
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_RATE_LIMIT,
+                               body=rate_limit,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
 
         httpretty.register_uri(httpretty.GET,
                                GITHUB_ISSUES_URL,
@@ -485,6 +548,16 @@ class TestGitHubBackend(unittest.TestCase):
 
         body = ""
         login = read_file('data/github/github_login')
+        rate_limit = read_file('data/github/rate_limit')
+
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_RATE_LIMIT,
+                               body=rate_limit,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
 
         httpretty.register_uri(httpretty.GET,
                                GITHUB_ISSUES_URL,
@@ -524,6 +597,16 @@ class TestGitHubBackend(unittest.TestCase):
         orgs = read_file('data/github/github_orgs')
         comments = read_file('data/github/github_issue_comments_1')
         reactions = read_file('data/github/github_issue_comment_1_reactions')
+        rate_limit = read_file('data/github/rate_limit')
+
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_RATE_LIMIT,
+                               body=rate_limit,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
 
         httpretty.register_uri(httpretty.GET,
                                GITHUB_ISSUES_URL,
@@ -587,8 +670,8 @@ class TestGitHubBackend(unittest.TestCase):
                                    'X-RateLimit-Reset': '15'
                                })
         github = GitHub("zhquan_example", "repo", "aaa")
-        with self.assertRaises(requests.exceptions.HTTPError) as e:
-            issues = [issues for issues in github.fetch()]
+        with self.assertRaises(requests.exceptions.HTTPError):
+            _ = [issues for issues in github.fetch()]
 
         GitHubClient._users_orgs = users_orgs  # restore the cache
 
@@ -615,6 +698,16 @@ class TestGitHubBackendCache(unittest.TestCase):
         issue_2_reactions = read_file('data/github/github_issue_2_reactions')
         issue_comment_1_reactions = read_file('data/github/github_issue_comment_1_reactions')
         issue_comment_2_reactions = read_file('data/github/github_empty_request')
+        rate_limit = read_file('data/github/rate_limit')
+
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_RATE_LIMIT,
+                               body=rate_limit,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
 
         httpretty.register_uri(httpretty.GET,
                                GITHUB_ISSUES_URL,
@@ -706,21 +799,44 @@ class TestGitHubBackendCache(unittest.TestCase):
         self.assertDictEqual(issues[0], cache_issues[0])
         self.assertDictEqual(issues[1], cache_issues[1])
 
+    @httpretty.activate
     def test_fetch_from_empty_cache(self):
         """Test if there are not any issues returned when the cache is empty"""
 
         cache = Cache(self.tmp_path)
+        rate_limit = read_file('data/github/rate_limit')
+
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_RATE_LIMIT,
+                               body=rate_limit,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+
         github = GitHub("zhquan_example", "repo", "aaa", cache=cache)
 
         cache_issues = [cache_issues for cache_issues in github.fetch_from_cache()]
 
         self.assertEqual(len(cache_issues), 0)
 
+    @httpretty.activate
     def test_fetch_from_non_set_cache(self):
         """Test if a error is raised when the cache was not set"""
 
-        github = GitHub("zhquan_example", "repo", "aaa")
+        rate_limit = read_file('data/github/rate_limit')
 
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_RATE_LIMIT,
+                               body=rate_limit,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+
+        github = GitHub("zhquan_example", "repo", "aaa")
         with self.assertRaises(CacheError):
             _ = [cache_issues for cache_issues in github.fetch_from_cache()]
 
@@ -728,8 +844,28 @@ class TestGitHubBackendCache(unittest.TestCase):
 class TestGitHubClient(unittest.TestCase):
     """ GitHub API client tests """
 
+    @httpretty.activate
     def test_api_url_initialization(self):
         """Test API URL initialization for both basic and enterprise servers"""
+
+        rate_limit = read_file('data/github/rate_limit')
+
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_RATE_LIMIT,
+                               body=rate_limit,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_ENTREPRISE_RATE_LIMIT,
+                               body=rate_limit,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
 
         client = GitHubClient("zhquan_example", "repo", "aaa")
         self.assertEqual(client.api_url, GITHUB_API_URL)
@@ -743,6 +879,16 @@ class TestGitHubClient(unittest.TestCase):
         """ Test get_issues API call """
 
         issue = read_file('data/github/github_request')
+        rate_limit = read_file('data/github/rate_limit')
+
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_RATE_LIMIT,
+                               body=rate_limit,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
 
         httpretty.register_uri(httpretty.GET,
                                GITHUB_ISSUES_URL,
@@ -773,6 +919,16 @@ class TestGitHubClient(unittest.TestCase):
         """Test fetching issues from enterprise"""
 
         issue = read_file('data/github/github_request')
+        rate_limit = read_file('data/github/rate_limit')
+
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_ENTREPRISE_RATE_LIMIT,
+                               body=rate_limit,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
 
         httpretty.register_uri(httpretty.GET,
                                GITHUB_ENTERPRISE_ISSUES_URL,
@@ -801,6 +957,16 @@ class TestGitHubClient(unittest.TestCase):
         """ Test get_from_issues API call """
 
         issue = read_file('data/github/github_request_from_2016_03_01')
+        rate_limit = read_file('data/github/rate_limit')
+
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_RATE_LIMIT,
+                               body=rate_limit,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
 
         httpretty.register_uri(httpretty.GET,
                                GITHUB_ISSUES_URL,
@@ -814,7 +980,7 @@ class TestGitHubClient(unittest.TestCase):
         from_date = datetime.datetime(2016, 3, 1)
         client = GitHubClient("zhquan_example", "repo", "aaa", None)
 
-        raw_issues = [issues for issues in client.issues(start=from_date)]
+        raw_issues = [issues for issues in client.issues(from_date=from_date)]
         self.assertEqual(len(raw_issues), 1)
         self.assertEqual(raw_issues[0], issue)
 
@@ -835,6 +1001,16 @@ class TestGitHubClient(unittest.TestCase):
 
         issue_1 = read_file('data/github/github_issue_1')
         issue_2 = read_file('data/github/github_issue_2')
+        rate_limit = read_file('data/github/rate_limit')
+
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_RATE_LIMIT,
+                               body=rate_limit,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
 
         httpretty.register_uri(httpretty.GET,
                                GITHUB_ISSUES_URL,
@@ -880,14 +1056,23 @@ class TestGitHubClient(unittest.TestCase):
         """Test when Abuse Rate Limit exception is thrown"""
 
         abuse_rate_limit = read_file('data/github/abuse_rate_limit')
+        rate_limit = read_file('data/github/rate_limit')
+
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_RATE_LIMIT,
+                               body=rate_limit,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
 
         httpretty.register_uri(httpretty.GET,
                                GITHUB_ISSUES_URL,
                                body=abuse_rate_limit, status=403,
                                forcing_headers={
                                    'X-RateLimit-Remaining': '5',
-                                   'X-RateLimit-Reset': '5',
-                                   'Retry-After': '1'
+                                   'X-RateLimit-Reset': '5'
                                })
 
         client = GitHubClient("zhquan_example", "repo", "aaa", None)
@@ -900,6 +1085,16 @@ class TestGitHubClient(unittest.TestCase):
         """ Test when issue is empty API call """
 
         issue = read_file('data/github/github_empty_request')
+        rate_limit = read_file('data/github/rate_limit')
+
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_RATE_LIMIT,
+                               body=rate_limit,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
 
         httpretty.register_uri(httpretty.GET,
                                GITHUB_ISSUES_URL,
@@ -930,6 +1125,16 @@ class TestGitHubClient(unittest.TestCase):
         """ Test get_user API call """
 
         login = read_file('data/github/github_login')
+        rate_limit = read_file('data/github/rate_limit')
+
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_RATE_LIMIT,
+                               body=rate_limit,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
 
         httpretty.register_uri(httpretty.GET,
                                GITHUB_USER_URL,
@@ -948,6 +1153,16 @@ class TestGitHubClient(unittest.TestCase):
         """ Test get_user_orgs API call """
 
         orgs = read_file('data/github/github_orgs')
+        rate_limit = read_file('data/github/rate_limit')
+
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_RATE_LIMIT,
+                               body=rate_limit,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
 
         httpretty.register_uri(httpretty.GET,
                                GITHUB_ORGS_URL,
@@ -967,6 +1182,16 @@ class TestGitHubClient(unittest.TestCase):
         """Test if a error is raised when the http status was not 200"""
 
         issue = ""
+        rate_limit = read_file('data/github/rate_limit')
+
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_RATE_LIMIT,
+                               body=rate_limit,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
 
         httpretty.register_uri(httpretty.GET,
                                GITHUB_ISSUES_URL,
@@ -977,7 +1202,7 @@ class TestGitHubClient(unittest.TestCase):
                                    'X-RateLimit-Reset': '15'
                                })
 
-        client = GitHubClient("zhquan_example", "repo", "aaa", None)
+        client = GitHubClient("zhquan_example", "repo", "aaa", default_sleep_time=1, max_retries=1)
 
         with self.assertRaises(requests.exceptions.HTTPError):
             _ = [issues for issues in client.issues()]
@@ -999,6 +1224,16 @@ class TestGitHubClient(unittest.TestCase):
 
         issue_1 = read_file('data/github/github_empty_request')
         issue_2 = read_file('data/github/github_empty_request')
+        rate_limit = read_file('data/github/rate_limit')
+
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_RATE_LIMIT,
+                               body=rate_limit,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
 
         wait = 1
         reset = int(time.time() + wait)
@@ -1051,6 +1286,16 @@ class TestGitHubClient(unittest.TestCase):
         """ Test get_page_issue API call """
 
         issue = read_file('data/github/github_empty_request')
+        rate_limit = read_file('data/github/rate_limit')
+
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_RATE_LIMIT,
+                               body=rate_limit,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
 
         httpretty.register_uri(httpretty.GET,
                                GITHUB_ISSUES_URL,
@@ -1096,6 +1341,8 @@ class TestGitHubCommand(unittest.TestCase):
 
         args = ['--sleep-for-rate',
                 '--min-rate-to-sleep', '1',
+                '--max-retries', '5',
+                '--default-sleep-time', '10',
                 '--tag', 'test', '--no-cache',
                 '--api-token', 'abcdefgh',
                 '--from-date', '1970-01-01',
@@ -1107,7 +1354,8 @@ class TestGitHubCommand(unittest.TestCase):
         self.assertEqual(parsed_args.repository, 'repo')
         self.assertEqual(parsed_args.base_url, 'https://example.com')
         self.assertEqual(parsed_args.sleep_for_rate, True)
-        self.assertEqual(parsed_args.min_rate_to_sleep, 1)
+        self.assertEqual(parsed_args.max_retries, 5)
+        self.assertEqual(parsed_args.default_sleep_time, 10)
         self.assertEqual(parsed_args.tag, 'test')
         self.assertEqual(parsed_args.from_date, DEFAULT_DATETIME)
         self.assertEqual(parsed_args.no_cache, True)

--- a/tests/test_hyperkitty.py
+++ b/tests/test_hyperkitty.py
@@ -73,7 +73,7 @@ class TestHyperKittyList(unittest.TestCase):
         self.assertIsInstance(hkls, MailingList)
         self.assertEqual(hkls.uri, HYPERKITTY_URL)
         self.assertEqual(hkls.dirpath, self.tmp_path)
-        self.assertEqual(hkls.url, HYPERKITTY_URL)
+        self.assertEqual(hkls.uri, HYPERKITTY_URL)
 
     @httpretty.activate
     @unittest.mock.patch('perceval.backends.core.hyperkitty.datetime_utcnow')

--- a/tests/test_jenkins.py
+++ b/tests/test_jenkins.py
@@ -409,7 +409,8 @@ class TestJenkinsClient(unittest.TestCase):
             _ = client.get_builds(JENKINS_JOB_BUILDS_1)
 
         end = float(time.time())
-        self.assertGreater(end, expected)
+
+        self.assertTrue(end > start)
 
 
 if __name__ == "__main__":

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -524,7 +524,7 @@ class TestJiraClient(unittest.TestCase):
                             user='user', password='password',
                             verify=False, cert=None, max_issues=100)
 
-        self.assertEqual(client.url, 'http://example.com')
+        self.assertEqual(client.base_url, 'http://example.com')
         self.assertEqual(client.project, 'perceval')
         self.assertEqual(client.user, 'user')
         self.assertEqual(client.password, 'password')

--- a/tests/test_launchpad.py
+++ b/tests/test_launchpad.py
@@ -682,7 +682,7 @@ class TestLaunchpadClient(unittest.TestCase):
         client = LaunchpadClient("mydistribution", consumer_key=CONSUMER_KEY, api_token=OAUTH_TOKEN,
                                  package='mypackage', items_per_page=2)
         from_date = datetime.datetime(2018, 8, 21, 16, 0, 0)
-        issues = [issues for issues in client.issues(start=from_date)]
+        issues = [issues for issues in client.issues(from_date=from_date)]
 
         self.assertEqual(len(issues), 1)
 


### PR DESCRIPTION
This PR proposes a generic client to deal with common problems (server errors, rate limit bans, connection losts) when fetching data from APIs.
The generic client has been successfully applied to the GitHub backend