### PR TITLE
[client] Add generic client (v2)

### DIFF
--- a/perceval/backends/core/askbot.py
+++ b/perceval/backends/core/askbot.py
@@ -35,6 +35,7 @@ from ...backend import (Backend,
                         BackendCommand,
                         BackendCommandArgumentParser,
                         metadata)
+from ...client import HttpClient
 from ...utils import DEFAULT_DATETIME
 
 
@@ -51,7 +52,7 @@ class Askbot(Backend):
     :param url: Askbot site URL
     :param tag: label used to mark the data
     """
-    version = '0.2.4'
+    version = '0.3.0'
 
     def __init__(self, url, tag=None):
         origin = url
@@ -78,19 +79,10 @@ class Askbot(Backend):
 
         from_date = datetime_to_utc(from_date).timestamp()
 
-        npages = 1
-        next_request = True
+        questions_groups = self.client.get_api_questions(AskbotClient.API_QUESTIONS)
+        for questions in questions_groups:
 
-        while next_request:
-            whole_page = self.client.get_api_questions(npages)
-            raw_questions = json.loads(whole_page)
-            questions = raw_questions['questions']
-            tpages = raw_questions['pages']
-
-            logger.debug("Fetching questions from '%s': page %s/%s",
-                         self.url, npages, tpages)
-
-            for question in questions:
+            for question in questions['questions']:
                 updated_at = int(question['last_activity_at'])
                 if updated_at > from_date:
                     html_question = self.__fetch_question(question)
@@ -102,11 +94,6 @@ class Askbot(Backend):
                     question_obj = self.__build_question(html_question, question, comments)
                     question.update(question_obj)
                     yield question
-
-            if npages == tpages:
-                next_request = False
-
-            npages = npages + 1
 
     def __fetch_question(self, question):
         """Fetch an Askbot HTML question body.
@@ -236,7 +223,7 @@ class Askbot(Backend):
         return question_object
 
 
-class AskbotClient:
+class AskbotClient(HttpClient):
     """Askbot client.
 
     This class implements a simple client to retrieve distinct
@@ -255,21 +242,46 @@ class AskbotClient:
     COMMENTS_OLD = 'post_comments'
 
     def __init__(self, base_url):
-        self.base_url = base_url
+        super().__init__(base_url)
         self._use_new_urls = True
 
-    def get_api_questions(self, page=1):
+    def get_api_questions(self, path):
         """Retrieve a question page using the API.
 
         :param page: page to retrieve
         """
-        path = self.API_QUESTIONS
-        params = {
-            'page': page,
-            'sort': self.ORDER_API
-        }
-        response = self.__call(path, params)
-        return response
+
+        npages = 1
+        next_request = True
+
+        path = urijoin(self.base_url, path)
+        while next_request:
+
+            try:
+                params = {
+                    'page': npages,
+                    'sort': self.ORDER_API
+                }
+
+                response = self.fetch(path, payload=params)
+
+                whole_page = response.text
+
+                raw_questions = json.loads(whole_page)
+                tpages = raw_questions['pages']
+
+                logger.debug("Fetching questions from '%s': page %s/%s",
+                             self.base_url, npages, tpages)
+
+                if npages == tpages:
+                    next_request = False
+
+                npages = npages + 1
+                yield raw_questions
+
+            except requests.exceptions.TooManyRedirects as e:
+                logger.warning("%s, data not retrieved for resource %s", e, path)
+                next_request = False
 
     def get_html_question(self, question_id, page=1):
         """Retrieve a raw HTML question and all it's information.
@@ -277,21 +289,25 @@ class AskbotClient:
         :param question_id: question identifier
         :param page: page to retrieve
         """
-        path = urijoin(self.HTML_QUESTION, question_id)
+
+        path = urijoin(self.base_url, self.HTML_QUESTION, question_id)
+
         params = {
             'page': page,
             'sort': self.ORDER_HTML
         }
 
-        response = self.__call(path, params)
-        return response
+        response = self.fetch(path, payload=params)
+        return response.text
 
     def get_comments(self, post_id):
         """Retrieve a list of comments by a given id.
 
         :param object_id: object identifiere
         """
-        path = self.COMMENTS if self._use_new_urls else self.COMMENTS_OLD
+
+        path = urijoin(self.base_url, self.COMMENTS if self._use_new_urls else self.COMMENTS_OLD)
+
         params = {
             'post_id': post_id,
             'post_type': 'answer',
@@ -300,33 +316,17 @@ class AskbotClient:
         headers = {'X-Requested-With': 'XMLHttpRequest'}
 
         try:
-            response = self.__call(path, params, headers)
+            response = self.fetch(path, payload=params, headers=headers)
         except requests.exceptions.HTTPError as ex:
             if ex.response.status_code == 404:
                 logger.debug("Comments URL did not work. Using old URL schema.")
                 self._use_new_urls = False
-                path = self.COMMENTS_OLD
-                response = self.__call(path, params, headers)
+                path = urijoin(self.base_url, self.COMMENTS_OLD)
+                response = self.fetch(path, payload=params, headers=headers)
             else:
                 raise ex
 
-        return response
-
-    def __call(self, path, params=None, headers=None):
-        """Retrieve all the questions.
-
-        :param path: path of the url
-        :param params: dict with the HTTP parameters needed to run
-            the given command
-        :param headers: headers to use in the request
-        """
-
-        url = urijoin(self.base_url, path)
-
-        req = requests.get(url, params=params, headers=headers)
-        req.raise_for_status()
-
-        return req.text
+        return response.text
 
 
 class AskbotParser:

--- a/perceval/backends/core/bugzillarest.py
+++ b/perceval/backends/core/bugzillarest.py
@@ -33,6 +33,7 @@ from ...backend import (Backend,
                         BackendCommand,
                         BackendCommandArgumentParser,
                         metadata)
+from ...client import HttpClient
 from ...errors import BaseError, BackendError, CacheError
 from ...utils import DEFAULT_DATETIME
 from ..._version import __version__
@@ -295,7 +296,7 @@ class BugzillaRESTError(BaseError):
     message = "%(error)s (code: %(code)s)"
 
 
-class BugzillaRESTClient:
+class BugzillaRESTClient(HttpClient):
     """Bugzilla REST API client.
 
     This class implements a simple client to retrieve distinct
@@ -343,7 +344,7 @@ class BugzillaRESTClient:
     VEXCLUDE_ATTCH_DATA = 'data'
 
     def __init__(self, base_url, user=None, password=None, api_token=None):
-        self.base_url = base_url
+        super().__init__(base_url)
         self.api_token = api_token if api_token else None
 
         if user is not None and password is not None:
@@ -462,8 +463,7 @@ class BugzillaRESTClient:
                      resource, str(params))
 
         headers = self.HEADERS
-        r = requests.get(url, headers=headers, params=params)
-        r.raise_for_status()
+        r = self.fetch(url, payload=params, headers=headers)
 
         # Check for possible Bugzilla API errors
         result = r.json()

--- a/perceval/client.py
+++ b/perceval/client.py
@@ -1,0 +1,236 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2017 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA.
+#
+# Authors:
+#     Valerio Cosentino <valcos@bitergia.com>
+#
+
+import logging
+import time
+
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util import Retry
+
+from .errors import RateLimitError
+
+logger = logging.getLogger(__name__)
+
+
+class HttpClient:
+    """Abstract class for HTTP clients.
+
+    Base class to query data sources taking care of retrying requests in case connection issues. If the data source does
+    not send back a response after retrying a request, a RetryError exception is thrown.
+
+    Sub-classes can use the methods fetch and _fetch to obtain data from the data source.
+
+    To track which version of the client was used during the fetching
+    process, this class provides a `version` attribute that each client
+    may override.
+
+    :param base_url: base URL of the data source
+    :param max_retries: number of max retries to a data source before raising a RetryError exception
+    :param max_retries_on_connect: max number of retries on connection error
+    :param max_retries_on_read: max number of retries on read errors
+    :param max_retries_on_redirect: max number of retries on redirects
+    :param max_retries_on_status: max number of retries on selected error status codes
+    :param status_forcelist: list of status codes where the retry attempts happen
+    :param method_whitelist: list of uppercased HTTP method verbs where the retry happen
+    :param raise_on_redirect: try retries on redirect status codes
+    :param raise_on_status: try retries on selected status codes
+    :param respect_retry_after_header: try retries for status code with retry-after headers
+    :param default_sleep_time: default time to sleep in case of connection problems
+    :param headers: list of session headers
+    """
+    version = '0.1'
+
+    DEFAULT_SLEEP_TIME = 1
+
+    MAX_RETRIES = 5
+    MAX_RETRIES_ON_CONNECT = 5
+    MAX_RETRIES_ON_READ = 5
+    MAX_RETRIES_ON_REDIRECT = 5
+    MAX_RETRIES_ON_STATUS = 5
+
+    DEFAULT_METHOD_WHITELIST = False
+    DEFAULT_RAISE_ON_REDIRECT = True
+    DEFAULT_RAISE_ON_STATUS = True
+    DEFAULT_RESPECT_RETRY_AFTER_HEADER = True
+
+    DEFAULT_RETRY_AFTER_STATUS_CODES = [413, 429, 503]
+    DEFAULT_STATUS_FORCE_LIST = [408, 423, 504]
+
+    GET = "GET"
+    POST = "POST"
+
+    def __init__(self, base_url, max_retries=MAX_RETRIES, max_retries_on_connect=MAX_RETRIES_ON_CONNECT,
+                 max_retries_on_read=MAX_RETRIES_ON_READ, max_retries_on_redirect=MAX_RETRIES_ON_REDIRECT,
+                 max_retries_on_status=MAX_RETRIES_ON_STATUS, status_forcelist=DEFAULT_STATUS_FORCE_LIST,
+                 method_whitelist=DEFAULT_METHOD_WHITELIST, raise_on_redirect=DEFAULT_RAISE_ON_REDIRECT,
+                 raise_on_status=DEFAULT_RAISE_ON_STATUS, respect_retry_after_header=DEFAULT_RESPECT_RETRY_AFTER_HEADER,
+                 default_sleep_time=DEFAULT_SLEEP_TIME, headers=None):
+        self.base_url = base_url
+
+        self.max_retries = max_retries
+        self.max_retries_on_connect = max_retries_on_connect
+        self.max_retries_on_read = max_retries_on_read
+        self.max_retries_on_redirect = max_retries_on_redirect
+        self.max_retries_on_status = max_retries_on_status
+        self.status_forcelist = status_forcelist
+        self.method_whitelist = method_whitelist
+        self.raise_on_redirect = raise_on_redirect
+        self.raise_on_status = raise_on_status
+        self.respect_retry_after_header = respect_retry_after_header
+        self.default_sleep_time = default_sleep_time
+
+        self._create_http_session(headers)
+
+    def __del__(self):
+        self._close_http_session()
+
+    def _create_http_session(self, headers=None):
+        """
+        Create a http session and initialize the retry object
+
+        :param headers: list of session headers
+        """
+        self.session = requests.Session()
+
+        if headers:
+            self.session.headers.update(headers)
+
+        retries = Retry(total=self.max_retries,
+                        connect=self.max_retries_on_connect,
+                        read=self.max_retries_on_read,
+                        redirect=self.max_retries_on_redirect,
+                        status=self.max_retries_on_status,
+                        method_whitelist=self.method_whitelist,
+                        status_forcelist=self.status_forcelist,
+                        backoff_factor=self.default_sleep_time,
+                        raise_on_redirect=self.raise_on_redirect,
+                        raise_on_status=self.raise_on_status,
+                        respect_retry_after_header=self.respect_retry_after_header)
+
+        self.session.mount('http://', HTTPAdapter(max_retries=retries))
+        self.session.mount('https://', HTTPAdapter(max_retries=retries))
+
+    def _close_http_session(self):
+        """Close the http session"""
+
+        self.session.close()
+
+    def fetch(self, url, payload=None, headers=None, method=GET, stream=False):
+        """
+        Fetch the data from a given URL
+
+        :param url: link to the resource
+        :param payload: payload of the request
+        :param headers: headers of the request
+        :param method: type of request call (GET or POST)
+        :param stream: defer downloading the response body until the response content is available
+        """
+        return self.__send_request(url, payload, headers, method, stream)
+
+    def __send_request(self, url, payload=None, headers=None, method=GET, stream=False):
+        """Send a HTTP request to a URL"""
+
+        if method == self.GET:
+            response = self.session.get(url, params=payload, headers=headers, stream=stream)
+        else:
+            response = self.session.post(url, data=payload, headers=headers, stream=stream)
+
+        response.raise_for_status()
+
+        return response
+
+
+class RateLimitHandler:
+    """Class to handle rate limit for HTTP clients.
+
+        :param sleep_for_rate: sleep until rate limit is reset
+        :param min_rate_to_sleep: minimun rate needed to sleep until it will be rese
+        :param rate_limit_header: header to know the current rate limit
+        :param rate_limit_reset_header: header to know the next rate limit reset
+        """
+    version = '0.1'
+
+    MIN_RATE_LIMIT = 10
+    MAX_RATE_LIMIT = 500
+    RATE_LIMIT_HEADER = "X-RateLimit-Remaining"
+    RATE_LIMIT_RESET_HEADER = "X-RateLimit-Reset"
+
+    def setup_rate_limit_handler(self, sleep_for_rate=False, min_rate_to_sleep=MIN_RATE_LIMIT,
+                                 rate_limit_header=RATE_LIMIT_HEADER, rate_limit_reset_header=RATE_LIMIT_RESET_HEADER):
+        self.rate_limit = None
+        self.rate_limit_reset_ts = None
+        self.sleep_for_rate = sleep_for_rate
+        self.rate_limit_header = rate_limit_header
+        self.rate_limit_reset_header = rate_limit_reset_header
+
+        if min_rate_to_sleep > self.MAX_RATE_LIMIT:
+            msg = "Minimum rate to sleep value exceeded (%d)."
+            msg += "High values might cause the client to sleep forever."
+            msg += "Reset to %d."
+            self.min_rate_to_sleep = self.MAX_RATE_LIMIT
+            logger.warning(msg, min_rate_to_sleep, self.MAX_RATE_LIMIT)
+        else:
+            self.min_rate_to_sleep = min_rate_to_sleep
+
+    def init_rate_limit(self, response):
+        """
+        initialize rate_limit and rate_limit_reset_ts
+
+        :param response: the response object
+        """
+
+        if self.rate_limit_header in response.headers:
+            self.rate_limit = int(response.headers[self.rate_limit_header])
+
+        if self.rate_limit_reset_header in response.headers:
+            self.rate_limit_reset_ts = int(response.headers[self.rate_limit_reset_header])
+
+    def sleep_for_rate_limit(self):
+        """
+        in case the rate limit is under the minimum rate limit threshold and the sleep_for_rate flag is enabled,
+        it sends the backend to sleep. Otherwise, it raises a RateLimitError exception
+        """
+
+        if self.rate_limit is not None and self.rate_limit <= self.min_rate_to_sleep:
+            seconds_to_reset = self.rate_limit_reset_ts - int(time.time()) + 1
+            cause = "Rate limit exhausted."
+            if self.sleep_for_rate:
+                logger.info("%s Waiting %i secs for rate limit reset.", cause, seconds_to_reset)
+                time.sleep(seconds_to_reset)
+            else:
+                raise RateLimitError(cause=cause, seconds_to_reset=seconds_to_reset)
+
+    def update_rate_limit(self, response):
+        """
+        update the rate limit left and the time to reset the rate limit from the response headers
+
+        :param: response: the response object
+        """
+
+        if self.rate_limit_header in response.headers:
+            self.rate_limit = int(response.headers[self.rate_limit_header])
+            self.rate_limit_reset_ts = int(response.headers[self.rate_limit_reset_header])
+            logger.debug("Rate limit: %s", self.rate_limit)
+        else:
+            self.rate_limit = None
+            self.rate_limit_reset_ts = None

--- a/perceval/errors.py
+++ b/perceval/errors.py
@@ -49,6 +49,12 @@ class CacheError(BaseError):
     message = "%(cause)s"
 
 
+class HttpClientError(BaseError):
+    """Generic error for HTTP Cient"""
+
+    message = "%(cause)s"
+
+
 class RepositoryError(BaseError):
     """Generic error for repositories"""
 

--- a/tests/test_askbot.py
+++ b/tests/test_askbot.py
@@ -215,9 +215,9 @@ class TestAskbotClient(unittest.TestCase):
 
         client = AskbotClient(ASKBOT_URL)
 
-        result = client.get_api_questions(1)
+        result = next(client.get_api_questions('api/v1/questions'))
 
-        self.assertEqual(result, body)
+        self.assertEqual(result, json.loads(body))
 
         expected = {
             'page': ['1'],

--- a/tests/test_bugzilla.py
+++ b/tests/test_bugzilla.py
@@ -728,7 +728,7 @@ class TestBugzillaClient(unittest.TestCase):
 
         client = BugzillaClient(BUGZILLA_SERVER_URL)
         self.assertEqual(client.version, None)
-        self.assertIsInstance(client._session, requests.Session)
+        self.assertIsInstance(client.session, requests.Session)
 
     @httpretty.activate
     def test_init_auth(self):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2017 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA.
+#
+# Authors:
+#     Valerio Cosentino <valcos@bitergia.com>
+#
+
+import os
+import sys
+import time
+import unittest
+
+import httpretty
+import pkg_resources
+import requests
+
+# Hack to make sure that tests import the right packages
+# due to setuptools behaviour
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), ".."))
+pkg_resources.declare_namespace('perceval.backends')
+
+from perceval.client import HttpClient, RateLimitHandler
+
+
+CLIENT_API_URL = "https://gateway.marvel.com/v1/"
+CLIENT_SPIDERMAN_URL = "https://gateway.marvel.com/v1/public/characters/1"
+CLIENT_SUPERMAN_URL = "https://gateway.marvel.com/v1/public/characters/2"
+CLIENT_BATMAN_URL = "https://gateway.marvel.com/v1/public/characters/3"
+CLIENT_IRONMAN_URL = "https://gateway.marvel.com/v1/public/characters/4"
+
+
+class MockedClient(HttpClient, RateLimitHandler):
+
+    def __init__(self, base_url, default_sleep_time=0.1, max_retries=1):
+
+        super().__init__(base_url, default_sleep_time=default_sleep_time, max_retries=max_retries)
+        super().setup_rate_limit_handler()
+
+
+class TestHttpClient(unittest.TestCase):
+    """Http client tests """
+
+    def test_initialization(self):
+        """Test whether attributes are initializated"""
+
+        client = MockedClient(CLIENT_API_URL)
+
+        self.assertEqual(client.base_url, CLIENT_API_URL)
+        self.assertEqual(client.max_retries, 1)
+        self.assertEqual(client.max_retries_on_connect, HttpClient.MAX_RETRIES_ON_CONNECT)
+        self.assertEqual(client.max_retries_on_read, HttpClient.MAX_RETRIES_ON_READ)
+        self.assertEqual(client.max_retries_on_redirect, HttpClient.MAX_RETRIES_ON_REDIRECT)
+        self.assertEqual(client.max_retries_on_read, HttpClient.MAX_RETRIES_ON_READ)
+        self.assertEqual(client.max_retries_on_status, HttpClient.MAX_RETRIES_ON_STATUS)
+        self.assertEqual(client.status_forcelist, HttpClient.DEFAULT_STATUS_FORCE_LIST)
+        self.assertEqual(client.method_whitelist, HttpClient.DEFAULT_METHOD_WHITELIST)
+        self.assertEqual(client.raise_on_redirect, HttpClient.DEFAULT_RAISE_ON_REDIRECT)
+        self.assertEqual(client.raise_on_status, HttpClient.DEFAULT_RAISE_ON_STATUS)
+        self.assertEqual(client.respect_retry_after_header, HttpClient.DEFAULT_RESPECT_RETRY_AFTER_HEADER)
+        self.assertEqual(client.default_sleep_time, 0.1)
+
+        self.assertIsNotNone(client.session)
+
+    @httpretty.activate
+    def test_close_session(self):
+        """Test wheter the session is properly closed"""
+
+        output = "success"
+        httpretty.register_uri(httpretty.GET,
+                               CLIENT_SPIDERMAN_URL,
+                               body=output,
+                               status=200)
+
+        client = MockedClient(CLIENT_API_URL)
+        response = client.fetch(CLIENT_SPIDERMAN_URL)
+        self.assertEqual(response.headers['connection'], 'close')
+
+    @httpretty.activate
+    def test_fetch(self):
+        """Test fetch method"""
+
+        output = "success"
+        httpretty.register_uri(httpretty.GET,
+                               CLIENT_SPIDERMAN_URL,
+                               body=output,
+                               status=200)
+
+        httpretty.register_uri(httpretty.POST,
+                               CLIENT_SPIDERMAN_URL,
+                               body=output,
+                               status=200)
+
+        httpretty.register_uri(httpretty.GET,
+                               CLIENT_SUPERMAN_URL,
+                               body=output,
+                               status=403)
+
+        client = MockedClient(CLIENT_API_URL)
+        response = client.fetch(CLIENT_SPIDERMAN_URL)
+
+        self.assertEqual(response.request.method, HttpClient.GET)
+        self.assertEqual(response.text, output)
+
+        response = client.fetch(CLIENT_SPIDERMAN_URL, method=HttpClient.POST)
+        self.assertEqual(response.request.method, HttpClient.POST)
+        self.assertEqual(response.text, output)
+
+        with self.assertRaises(requests.exceptions.HTTPError):
+            _ = client.fetch(CLIENT_SUPERMAN_URL)
+
+    @httpretty.activate
+    def test_fetch_retry_after(self):
+        """Test whether calls returning 503, 413, 429 status codes are retried"""
+
+        retry_after_value = 1
+
+        httpretty.register_uri(httpretty.GET,
+                               CLIENT_SPIDERMAN_URL,
+                               body="",
+                               status=413,
+                               forcing_headers={
+                                   'Retry-After': str(retry_after_value)
+                               })
+
+        httpretty.register_uri(httpretty.GET,
+                               CLIENT_SUPERMAN_URL,
+                               body="",
+                               status=429,
+                               forcing_headers={
+                                   'Retry-After': str(retry_after_value)
+                               })
+
+        httpretty.register_uri(httpretty.GET,
+                               CLIENT_BATMAN_URL,
+                               body="",
+                               status=503,
+                               forcing_headers={
+                                   'Retry-After': str(retry_after_value)
+                               })
+
+        client = MockedClient(CLIENT_API_URL)
+
+        urls = [CLIENT_SPIDERMAN_URL, CLIENT_SUPERMAN_URL, CLIENT_BATMAN_URL]
+
+        for url in urls:
+            before = int(time.time())
+            expected = before + (retry_after_value * client.max_retries)
+
+            with self.assertRaises(requests.exceptions.HTTPError):
+                _ = client.fetch(url)
+
+            after = int(time.time())
+            self.assertTrue(expected <= after)
+
+    @httpretty.activate
+    def test_fetch_retry(self):
+        """Test whether calls returning redirect status codes and 408, 423, 504 status codes are retried"""
+
+        httpretty.register_uri(httpretty.GET,
+                               CLIENT_IRONMAN_URL,
+                               body="",
+                               status=301)
+
+        httpretty.register_uri(httpretty.GET,
+                               CLIENT_SPIDERMAN_URL,
+                               body="",
+                               status=408)
+
+        httpretty.register_uri(httpretty.GET,
+                               CLIENT_SUPERMAN_URL,
+                               body="",
+                               status=423)
+
+        httpretty.register_uri(httpretty.GET,
+                               CLIENT_BATMAN_URL,
+                               body="",
+                               status=504)
+
+        client = MockedClient(CLIENT_API_URL)
+
+        urls = [CLIENT_SPIDERMAN_URL, CLIENT_SUPERMAN_URL, CLIENT_BATMAN_URL]
+
+        for url in urls:
+            with self.assertRaises(requests.exceptions.RetryError):
+                _ = client.fetch(url)
+
+    @httpretty.activate
+    def test_init_rate_limit(self):
+        """Test init rate limit"""
+
+        httpretty.register_uri(httpretty.GET,
+                               CLIENT_SPIDERMAN_URL,
+                               body="",
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+
+        httpretty.register_uri(httpretty.GET,
+                               CLIENT_SUPERMAN_URL,
+                               body="",
+                               status=200)
+
+        client = MockedClient(CLIENT_API_URL)
+        response = client.fetch(CLIENT_SPIDERMAN_URL)
+        client.init_rate_limit(response)
+
+        self.assertEqual(client.rate_limit, 20)
+        self.assertEqual(client.rate_limit_reset_ts, 15)
+
+        client = MockedClient(CLIENT_API_URL)
+        response = client.fetch(CLIENT_SUPERMAN_URL)
+        client.init_rate_limit(response)
+
+        self.assertEqual(client.rate_limit, None)
+        self.assertEqual(client.rate_limit_reset_ts, None)
+
+
+if __name__ == "__main__":
+    unittest.main(warnings='ignore')

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -41,6 +41,7 @@ pkg_resources.declare_namespace('perceval.backends')
 
 from perceval.backend import BackendCommandArgumentParser
 from perceval.cache import Cache
+from perceval.client import RateLimitHandler
 from perceval.errors import CacheError, RateLimitError
 from perceval.utils import DEFAULT_DATETIME
 from perceval.backends.core.github import (GitHub,
@@ -91,8 +92,10 @@ class TestGitHubBackend(unittest.TestCase):
                                GITHUB_RATE_LIMIT,
                                body=rate_limit,
                                status=200,
-                               forcing_headers={'X-RateLimit-Remaining': '20',
-                                                'X-RateLimit-Reset': '15'})
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
 
         github = GitHub('zhquan_example', 'repo', 'aaa', tag='test')
 
@@ -669,8 +672,8 @@ class TestGitHubBackend(unittest.TestCase):
                                    'X-RateLimit-Reset': '15'
                                })
         github = GitHub("zhquan_example", "repo", "aaa")
-        with self.assertRaises(requests.exceptions.HTTPError) as e:
-            issues = [issues for issues in github.fetch()]
+        with self.assertRaises(requests.exceptions.HTTPError):
+            _ = [issues for issues in github.fetch()]
 
         GitHubClient._users_orgs = users_orgs  # restore the cache
 
@@ -814,6 +817,17 @@ class TestGitHubBackendCache(unittest.TestCase):
                                })
 
         cache = Cache(self.tmp_path)
+        rate_limit = read_file('data/github/rate_limit')
+
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_RATE_LIMIT,
+                               body=rate_limit,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+
         github = GitHub("zhquan_example", "repo", "aaa", cache=cache)
 
         cache_issues = [cache_issues for cache_issues in github.fetch_from_cache()]
@@ -836,13 +850,39 @@ class TestGitHubBackendCache(unittest.TestCase):
                                })
 
         github = GitHub("zhquan_example", "repo", "aaa")
-
         with self.assertRaises(CacheError):
             _ = [cache_issues for cache_issues in github.fetch_from_cache()]
 
 
 class TestGitHubClient(unittest.TestCase):
     """ GitHub API client tests """
+
+    @httpretty.activate
+    def test_init(self):
+        rate_limit = read_file('data/github/rate_limit')
+        httpretty.register_uri(httpretty.GET,
+                               GITHUB_RATE_LIMIT,
+                               body=rate_limit,
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+
+        client = GitHubClient('zhquan_example', 'repo', 'aaa')
+
+        self.assertEqual(client.owner, 'zhquan_example')
+        self.assertEqual(client.repository, 'repo')
+        self.assertEqual(client.max_retries, GitHubClient.MAX_RETRIES)
+        self.assertEqual(client.default_sleep_time, GitHubClient.DEFAULT_SLEEP_TIME)
+        self.assertEqual(client.max_retries, GitHubClient.MAX_RETRIES)
+        self.assertEqual(client.base_url, 'https://api.github.com')
+
+        client = GitHubClient('zhquan_example', 'repo', 'aaa', min_rate_to_sleep=RateLimitHandler.MAX_RATE_LIMIT + 1)
+        self.assertEqual(client.min_rate_to_sleep, RateLimitHandler.MAX_RATE_LIMIT)
+
+        client = GitHubClient('zhquan_example', 'repo', 'aaa', min_rate_to_sleep=RateLimitHandler.MAX_RATE_LIMIT - 1)
+        self.assertEqual(client.min_rate_to_sleep, RateLimitHandler.MAX_RATE_LIMIT - 1)
 
     @httpretty.activate
     def test_api_url_initialization(self):
@@ -869,11 +909,11 @@ class TestGitHubClient(unittest.TestCase):
                                })
 
         client = GitHubClient("zhquan_example", "repo", "aaa")
-        self.assertEqual(client.api_url, GITHUB_API_URL)
+        self.assertEqual(client.base_url, GITHUB_API_URL)
 
         client = GitHubClient("zhquan_example", "repo", "aaa",
                               base_url=GITHUB_ENTERPRISE_URL)
-        self.assertEqual(client.api_url, GITHUB_ENTERPRISE_API_URL)
+        self.assertEqual(client.base_url, GITHUB_ENTERPRISE_API_URL)
 
     @httpretty.activate
     def test_get_issues(self):
@@ -981,7 +1021,7 @@ class TestGitHubClient(unittest.TestCase):
         from_date = datetime.datetime(2016, 3, 1)
         client = GitHubClient("zhquan_example", "repo", "aaa", None)
 
-        raw_issues = [issues for issues in client.issues(start=from_date)]
+        raw_issues = [issues for issues in client.issues(from_date=from_date)]
         self.assertEqual(len(raw_issues), 1)
         self.assertEqual(raw_issues[0], issue)
 
@@ -1072,17 +1112,18 @@ class TestGitHubClient(unittest.TestCase):
 
         httpretty.register_uri(httpretty.GET,
                                GITHUB_ISSUES_URL,
-                               body=abuse_rate_limit, status=403,
+                               body=abuse_rate_limit, status=429,
                                forcing_headers={
                                    'X-RateLimit-Remaining': '5',
                                    'X-RateLimit-Reset': '5',
                                    'Retry-After': str(retry_after_value)
                                })
 
+        GitHubClient.MAX_RETRIES_ON_READ = 2
         client = GitHubClient("zhquan_example", "repo", "aaa", None)
 
         before = int(time.time())
-        expected = before + (retry_after_value * GitHubClient.MAX_RETRIES)
+        expected = before + (retry_after_value * client.max_retries_on_status)
 
         with self.assertRaises(requests.exceptions.HTTPError):
             _ = [issues for issues in client.issues()]
@@ -1212,7 +1253,7 @@ class TestGitHubClient(unittest.TestCase):
                                    'X-RateLimit-Reset': '15'
                                })
 
-        client = GitHubClient("zhquan_example", "repo", "aaa", None)
+        client = GitHubClient("zhquan_example", "repo", "aaa", default_sleep_time=1, max_retries=1)
 
         with self.assertRaises(requests.exceptions.HTTPError):
             _ = [issues for issues in client.issues()]
@@ -1351,6 +1392,8 @@ class TestGitHubCommand(unittest.TestCase):
 
         args = ['--sleep-for-rate',
                 '--min-rate-to-sleep', '1',
+                '--max-retries', '5',
+                '--default-sleep-time', '10',
                 '--tag', 'test', '--no-cache',
                 '--api-token', 'abcdefgh',
                 '--from-date', '1970-01-01',
@@ -1362,7 +1405,8 @@ class TestGitHubCommand(unittest.TestCase):
         self.assertEqual(parsed_args.repository, 'repo')
         self.assertEqual(parsed_args.base_url, 'https://example.com')
         self.assertEqual(parsed_args.sleep_for_rate, True)
-        self.assertEqual(parsed_args.min_rate_to_sleep, 1)
+        self.assertEqual(parsed_args.max_retries, 5)
+        self.assertEqual(parsed_args.default_sleep_time, 10)
         self.assertEqual(parsed_args.tag, 'test')
         self.assertEqual(parsed_args.from_date, DEFAULT_DATETIME)
         self.assertEqual(parsed_args.no_cache, True)


### PR DESCRIPTION
This PR proposes a generic client (and replaces PR #208)  to deal with common problems (server errors, rate limit bans, connection losts) when fetching data from APIs.
The generic client has been successfully applied to the GitHub backend.

