### PR TITLE
[github] Handle init rate limit for GitHub entreprise

### DIFF
--- a/perceval/backends/core/github.py
+++ b/perceval/backends/core/github.py
@@ -69,7 +69,7 @@ class GitHub(Backend):
     :param min_rate_to_sleep: minimun rate needed to sleep until
          it will be reset
     """
-    version = '0.11.3'
+    version = '0.11.4'
 
     def __init__(self, owner=None, repository=None,
                  api_token=None, base_url=None,
@@ -474,7 +474,7 @@ class GitHubClient:
         else:
             self.api_url = GITHUB_API_URL
 
-        self.init_rate_limit(self.get_rate_limit())
+        self.init_rate_limit()
 
         if min_rate_to_sleep > MAX_RATE_LIMIT:
             msg = "Minimum rate to sleep value exceeded (%d)."
@@ -484,17 +484,17 @@ class GitHubClient:
 
         self.min_rate_to_sleep = min(min_rate_to_sleep, MAX_RATE_LIMIT)
 
-    def get_rate_limit(self):
-        """Get rate limit"""
+    def init_rate_limit(self):
+        """initialize rate_limit and rate_limit_reset_ts """
 
         url = urijoin(self.api_url, "rate_limit")
-        response = requests.get(url, headers=self.__build_headers())
-        response.raise_for_status()
-
-        return response
-
-    def init_rate_limit(self, response):
-        """initialize rate_limit and rate_limit_reset_ts """
+        try:
+            response = requests.get(url, headers=self.__build_headers())
+            response.raise_for_status()
+        except requests.exceptions.HTTPError:
+            self.rate_limit = None
+            self.rate_limit_reset_ts = None
+            return
 
         self.rate_limit = int(response.headers[self.RATE_LIMIT_HEADER])
         self.rate_limit_reset_ts = int(response.headers[self.RATE_LIMIT_RESET_HEADER])

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -386,16 +386,11 @@ class TestGitHubBackend(unittest.TestCase):
         issue_2_comments = read_file('data/github/github_issue_comments_2')
         issue_comment_1_reactions = read_file('data/github/github_issue_comment_1_reactions')
         issue_comment_2_reactions = read_file('data/github/github_empty_request')
-        rate_limit = read_file('data/github/rate_limit')
 
         httpretty.register_uri(httpretty.GET,
                                GITHUB_ENTREPRISE_RATE_LIMIT,
-                               body=rate_limit,
-                               status=200,
-                               forcing_headers={
-                                   'X-RateLimit-Remaining': '20',
-                                   'X-RateLimit-Reset': '15'
-                               })
+                               body="",
+                               status=404)
 
         httpretty.register_uri(httpretty.GET,
                                GITHUB_ENTERPRISE_ISSUES_URL,
@@ -861,19 +856,19 @@ class TestGitHubClient(unittest.TestCase):
 
         httpretty.register_uri(httpretty.GET,
                                GITHUB_ENTREPRISE_RATE_LIMIT,
-                               body=rate_limit,
-                               status=200,
-                               forcing_headers={
-                                   'X-RateLimit-Remaining': '20',
-                                   'X-RateLimit-Reset': '15'
-                               })
+                               body="",
+                               status=404)
 
         client = GitHubClient("zhquan_example", "repo", "aaa")
         self.assertEqual(client.api_url, GITHUB_API_URL)
+        self.assertEqual(client.rate_limit, 20)
+        self.assertEqual(client.rate_limit_reset_ts, 15)
 
         client = GitHubClient("zhquan_example", "repo", "aaa",
                               base_url=GITHUB_ENTERPRISE_URL)
         self.assertEqual(client.api_url, GITHUB_ENTERPRISE_API_URL)
+        self.assertEqual(client.rate_limit, None)
+        self.assertEqual(client.rate_limit_reset_ts, None)
 
     @httpretty.activate
     def test_get_issues(self):
@@ -920,16 +915,11 @@ class TestGitHubClient(unittest.TestCase):
         """Test fetching issues from enterprise"""
 
         issue = read_file('data/github/github_request')
-        rate_limit = read_file('data/github/rate_limit')
 
         httpretty.register_uri(httpretty.GET,
                                GITHUB_ENTREPRISE_RATE_LIMIT,
-                               body=rate_limit,
-                               status=200,
-                               forcing_headers={
-                                   'X-RateLimit-Remaining': '20',
-                                   'X-RateLimit-Reset': '15'
-                               })
+                               body="",
+                               status=404)
 
         httpretty.register_uri(httpretty.GET,
                                GITHUB_ENTERPRISE_ISSUES_URL,


### PR DESCRIPTION
This patch allows to disable the initialization of the rate limit for GitHub entreprise repositories