### PR TITLE
[jenkins] Handle SSL EOF error

### DIFF
--- a/perceval/backends/core/jenkins.py
+++ b/perceval/backends/core/jenkins.py
@@ -233,7 +233,7 @@ class JenkinsClient:
                 req = requests.get(url)
                 req.raise_for_status()
                 break
-            except requests.exceptions.RequestException as e:
+            except requests.exceptions.HTTPError as e:
                 if e.response.status_code in [408, 410, 502, 503, 504]:
                     retries += 1
                     time.sleep(self.sleep_time * retries)


### PR DESCRIPTION
This patch targets issue #216. SSL errors are now handled in a dedicated except block following the same retry strategy done for HTTP errors