### PR TITLE
[http-client] Generic client for backends querying APIs

### DIFF
--- a/perceval/client.py
+++ b/perceval/client.py
@@ -1,0 +1,223 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2017 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA.
+#
+# Authors:
+#     Valerio Cosentino <valcos@bitergia.com>
+#
+
+import logging
+import time
+
+import requests
+import urllib3.util
+
+from .errors import RateLimitError
+from ._version import __version__
+
+logger = logging.getLogger(__name__)
+
+
+class HttpClient:
+    """Abstract class for HTTP clients.
+
+    Base class to query data sources taking care of retrying
+    requests in case connection issues. If the data source
+    does not send back a response after retrying a request,
+    a RetryError exception is thrown.
+
+    Sub-classes can use the methods fetch to obtain data
+    from the data source.
+
+    To track which version of the client was used during
+    the fetching process, this class provides a `version`
+    attribute that each client may override.
+
+    :param base_url: base URL of the data source
+    :param max_retries: number of max retries to a data source
+        before raising a RetryError exception
+    :param status_forcelist: list of status codes where the retry
+        attempts occur
+    :param default_sleep_time: default time to sleep in case
+        of connection problems
+    :param headers: list of session headers
+    """
+    version = '0.1'
+
+    DEFAULT_SLEEP_TIME = 1
+
+    MAX_RETRIES = 5
+    MAX_RETRIES_ON_CONNECT = 5
+    MAX_RETRIES_ON_READ = 5
+    MAX_RETRIES_ON_REDIRECT = 5
+    MAX_RETRIES_ON_STATUS = 5
+
+    DEFAULT_METHOD_WHITELIST = False
+    DEFAULT_RAISE_ON_REDIRECT = True
+    DEFAULT_RAISE_ON_STATUS = True
+    DEFAULT_RESPECT_RETRY_AFTER_HEADER = True
+
+    DEFAULT_RETRY_AFTER_STATUS_CODES = [413, 429, 503]
+    DEFAULT_STATUS_FORCE_LIST = [408, 423, 504]
+
+    DEFAULT_HEADERS = {'User-Agent': 'Perceval/' + __version__}
+
+    GET = "GET"
+    POST = "POST"
+
+    def __init__(self, base_url, max_retries=MAX_RETRIES, status_forcelist=DEFAULT_STATUS_FORCE_LIST,
+                 default_sleep_time=DEFAULT_SLEEP_TIME, headers=DEFAULT_HEADERS):
+
+        self.base_url = base_url
+
+        self.headers = headers
+        self.max_retries = max_retries
+        self.max_retries_on_connect = self.MAX_RETRIES_ON_CONNECT
+        self.max_retries_on_read = self.MAX_RETRIES_ON_READ
+        self.max_retries_on_redirect = self.MAX_RETRIES_ON_REDIRECT
+        self.max_retries_on_status = self.MAX_RETRIES_ON_STATUS
+        self.status_forcelist = status_forcelist
+        self.method_whitelist = self.DEFAULT_METHOD_WHITELIST
+        self.raise_on_redirect = self.DEFAULT_RAISE_ON_REDIRECT
+        self.raise_on_status = self.DEFAULT_RAISE_ON_STATUS
+        self.respect_retry_after_header = self.DEFAULT_RESPECT_RETRY_AFTER_HEADER
+        self.default_sleep_time = default_sleep_time
+
+        self._create_http_session()
+
+    def __del__(self):
+        self._close_http_session()
+
+    def fetch(self, url, payload=None, headers=None, method=GET, stream=False):
+        """Fetch the data from a given URL.
+
+        :param url: link to the resource
+        :param payload: payload of the request
+        :param headers: headers of the request
+        :param method: type of request call (GET or POST)
+        :param stream: defer downloading the response body until the response content is available
+
+        :returns a response object
+        """
+        if method == self.GET:
+            response = self.session.get(url, params=payload, headers=headers, stream=stream)
+        else:
+            response = self.session.post(url, data=payload, headers=headers, stream=stream)
+
+        response.raise_for_status()
+
+        return response
+
+    def _create_http_session(self):
+        """Create a http session and initialize the retry object."""
+
+        self.session = requests.Session()
+
+        if self.headers:
+            self.session.headers.update(self.headers)
+
+        retries = urllib3.util.Retry(total=self.max_retries,
+                                     connect=self.max_retries_on_connect,
+                                     read=self.max_retries_on_read,
+                                     redirect=self.max_retries_on_redirect,
+                                     status=self.max_retries_on_status,
+                                     method_whitelist=self.method_whitelist,
+                                     status_forcelist=self.status_forcelist,
+                                     backoff_factor=self.default_sleep_time,
+                                     raise_on_redirect=self.raise_on_redirect,
+                                     raise_on_status=self.raise_on_status,
+                                     respect_retry_after_header=self.respect_retry_after_header)
+
+        self.session.mount('http://', requests.adapters.HTTPAdapter(max_retries=retries))
+        self.session.mount('https://', requests.adapters.HTTPAdapter(max_retries=retries))
+
+    def _close_http_session(self):
+        """Close the http session."""
+
+        self.session.close()
+
+
+class RateLimitHandler:
+    """Class to handle rate limit for HTTP clients.
+
+    :param sleep_for_rate: sleep until rate limit is reset
+    :param min_rate_to_sleep: minimun rate needed to sleep until it will be rese
+    :param rate_limit_header: header to know the current rate limit
+    :param rate_limit_reset_header: header to know the next rate limit reset
+    """
+    version = '0.1'
+
+    MIN_RATE_LIMIT = 10
+    MAX_RATE_LIMIT = 500
+    RATE_LIMIT_HEADER = "X-RateLimit-Remaining"
+    RATE_LIMIT_RESET_HEADER = "X-RateLimit-Reset"
+
+    def setup_rate_limit_handler(self, sleep_for_rate=False, min_rate_to_sleep=MIN_RATE_LIMIT,
+                                 rate_limit_header=RATE_LIMIT_HEADER,
+                                 rate_limit_reset_header=RATE_LIMIT_RESET_HEADER):
+        """Setup the rate limit handler.
+
+        :param sleep_for_rate: sleep until rate limit is reset
+        :param min_rate_to_sleep: minimun rate needed to make the fecthing process sleep
+        :param rate_limit_header: header from where extract the rate limit data
+        :param rate_limit_reset_header: header from where extract the rate limit reset data
+        """
+        self.rate_limit = None
+        self.rate_limit_reset_ts = None
+        self.sleep_for_rate = sleep_for_rate
+        self.rate_limit_header = rate_limit_header
+        self.rate_limit_reset_header = rate_limit_reset_header
+
+        if min_rate_to_sleep > self.MAX_RATE_LIMIT:
+            msg = "Minimum rate to sleep value exceeded (%d)."
+            msg += "High values might cause the client to sleep forever."
+            msg += "Reset to %d."
+            self.min_rate_to_sleep = self.MAX_RATE_LIMIT
+            logger.warning(msg, min_rate_to_sleep, self.MAX_RATE_LIMIT)
+        else:
+            self.min_rate_to_sleep = min_rate_to_sleep
+
+    def sleep_for_rate_limit(self):
+        """The fetching process sleeps until the rate limit is restored or
+           raises a RateLimitError exception if sleep_for_rate flag is disabled.
+        """
+        if self.rate_limit is not None and self.rate_limit <= self.min_rate_to_sleep:
+            seconds_to_reset = self.rate_limit_reset_ts - int(time.time()) + 1
+            cause = "Rate limit exhausted."
+            if self.sleep_for_rate:
+                logger.info("%s Waiting %i secs for rate limit reset.", cause, seconds_to_reset)
+                time.sleep(seconds_to_reset)
+            else:
+                raise RateLimitError(cause=cause, seconds_to_reset=seconds_to_reset)
+
+    def update_rate_limit(self, response):
+        """Update the rate limit and the time to reset the rate limit
+           from the response headers.
+
+        :param: response: the response object
+        """
+        if self.rate_limit_header in response.headers:
+            self.rate_limit = int(response.headers[self.rate_limit_header])
+            logger.debug("Rate limit: %s", self.rate_limit)
+        else:
+            self.rate_limit = None
+
+        if self.rate_limit_reset_header in response.headers:
+            self.rate_limit_reset_ts = int(response.headers[self.rate_limit_reset_header])
+            logger.debug("Rate limit reset: %s", self.rate_limit_reset_ts)
+        else:
+            self.rate_limit_reset_ts = None

--- a/perceval/errors.py
+++ b/perceval/errors.py
@@ -49,6 +49,12 @@ class CacheError(BaseError):
     message = "%(cause)s"
 
 
+class HttpClientError(BaseError):
+    """Generic error for HTTP Cient"""
+
+    message = "%(cause)s"
+
+
 class RepositoryError(BaseError):
     """Generic error for repositories"""
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ requests>=2.7.0
 beautifulsoup4>=4.3.2
 feedparser>=5.1.3
 dulwich>=0.18.5
+urllib3>=1.22
 -e git+https://github.com/grimoirelab/grimoirelab-toolkit/#egg=grimoirelab-toolkit

--- a/setup.py
+++ b/setup.py
@@ -81,6 +81,7 @@ setup(name="perceval",
           'beautifulsoup4>=4.3.2',
           'feedparser>=5.1.3',
           'dulwich>=0.18.5',
+          'urllib3>=1.22',
           'grimoirelab-toolkit>=0.1.1'
       ],
       scripts=[

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,371 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2017 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA.
+#
+# Authors:
+#     Valerio Cosentino <valcos@bitergia.com>
+#
+
+import os
+import sys
+import time
+import unittest
+
+import httpretty
+import pkg_resources
+import requests
+
+# Hack to make sure that tests import the right packages
+# due to setuptools behaviour
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), ".."))
+pkg_resources.declare_namespace('perceval.backends')
+
+from perceval.client import HttpClient, RateLimitHandler
+from perceval.errors import RateLimitError
+
+
+CLIENT_API_URL = "https://gateway.marvel.com/v1/"
+CLIENT_SPIDERMAN_URL = "https://gateway.marvel.com/v1/public/characters/1"
+CLIENT_SUPERMAN_URL = "https://gateway.marvel.com/v1/public/characters/2"
+CLIENT_BATMAN_URL = "https://gateway.marvel.com/v1/public/characters/3"
+CLIENT_IRONMAN_URL = "https://gateway.marvel.com/v1/public/characters/4"
+
+
+class MockedClient(HttpClient, RateLimitHandler):
+
+    def __init__(self, base_url, default_sleep_time=0.1, max_retries=1,
+                 status_force_list=HttpClient.DEFAULT_STATUS_FORCE_LIST,
+                 headers=HttpClient.DEFAULT_HEADERS, sleep_for_rate=False,
+                 min_rate_to_sleep=RateLimitHandler.MIN_RATE_LIMIT,
+                 rate_limit_header=RateLimitHandler.RATE_LIMIT_HEADER,
+                 rate_limit_reset_header=RateLimitHandler.RATE_LIMIT_RESET_HEADER):
+
+        super().__init__(base_url, default_sleep_time=default_sleep_time, max_retries=max_retries,
+                         status_forcelist=status_force_list, headers=headers)
+        super().setup_rate_limit_handler(sleep_for_rate=sleep_for_rate,
+                                         min_rate_to_sleep=min_rate_to_sleep,
+                                         rate_limit_header=rate_limit_header,
+                                         rate_limit_reset_header=rate_limit_reset_header)
+
+
+class TestHttpClient(unittest.TestCase):
+    """Http client tests"""
+
+    def test_initialization(self):
+        """Test whether attributes are initializated"""
+
+        expected_retries = 5
+        expected_sleep_time = 100
+        expected_headers = {'User-Agent': 'ACME Corp.'}
+
+        client = MockedClient(CLIENT_API_URL,
+                              max_retries=expected_retries,
+                              default_sleep_time=expected_sleep_time,
+                              headers=expected_headers)
+
+        self.assertEqual(client.base_url, CLIENT_API_URL)
+        self.assertEqual(client.max_retries, expected_retries)
+        self.assertEqual(client.max_retries_on_connect, HttpClient.MAX_RETRIES_ON_CONNECT)
+        self.assertEqual(client.max_retries_on_read, HttpClient.MAX_RETRIES_ON_READ)
+        self.assertEqual(client.max_retries_on_redirect, HttpClient.MAX_RETRIES_ON_REDIRECT)
+        self.assertEqual(client.max_retries_on_read, HttpClient.MAX_RETRIES_ON_READ)
+        self.assertEqual(client.max_retries_on_status, HttpClient.MAX_RETRIES_ON_STATUS)
+        self.assertEqual(client.status_forcelist, HttpClient.DEFAULT_STATUS_FORCE_LIST)
+        self.assertEqual(client.method_whitelist, HttpClient.DEFAULT_METHOD_WHITELIST)
+        self.assertEqual(client.raise_on_redirect, HttpClient.DEFAULT_RAISE_ON_REDIRECT)
+        self.assertEqual(client.raise_on_status, HttpClient.DEFAULT_RAISE_ON_STATUS)
+        self.assertEqual(client.respect_retry_after_header, HttpClient.DEFAULT_RESPECT_RETRY_AFTER_HEADER)
+        self.assertEqual(client.default_sleep_time, expected_sleep_time)
+
+        self.assertIsNotNone(client.session)
+        self.assertEqual(client.session.headers['User-Agent'], expected_headers.get('User-Agent'))
+
+        self.assertEqual(client.rate_limit, None)
+        self.assertEqual(client.rate_limit_reset_ts, None)
+
+        client = MockedClient(CLIENT_API_URL,
+                              max_retries=HttpClient.MAX_RETRIES,
+                              default_sleep_time=HttpClient.DEFAULT_SLEEP_TIME)
+
+        self.assertEqual(client.session.headers['User-Agent'], HttpClient.DEFAULT_HEADERS.get('User-Agent'))
+        self.assertEqual(client.max_retries, HttpClient.MAX_RETRIES)
+        self.assertEqual(client.default_sleep_time, HttpClient.DEFAULT_SLEEP_TIME)
+
+    @httpretty.activate
+    def test_close_session(self):
+        """Test wheter the session is properly closed"""
+
+        output = "success"
+        httpretty.register_uri(httpretty.GET,
+                               CLIENT_SPIDERMAN_URL,
+                               body=output,
+                               status=200)
+
+        client = MockedClient(CLIENT_API_URL)
+        response = client.fetch(CLIENT_SPIDERMAN_URL)
+        self.assertEqual(response.headers['connection'], 'close')
+
+    @httpretty.activate
+    def test_fetch_get(self):
+        """Test fetch method"""
+
+        output = "success"
+        httpretty.register_uri(httpretty.GET,
+                               CLIENT_SPIDERMAN_URL,
+                               body=output,
+                               status=200)
+
+        client = MockedClient(CLIENT_API_URL)
+        response = client.fetch(CLIENT_SPIDERMAN_URL)
+
+        self.assertEqual(response.request.method, HttpClient.GET)
+        self.assertEqual(response.text, output)
+
+    @httpretty.activate
+    def test_fetch_http_error(self):
+        """Test fetch method"""
+
+        httpretty.register_uri(httpretty.GET,
+                               CLIENT_SUPERMAN_URL,
+                               body="",
+                               status=403)
+
+        client = MockedClient(CLIENT_API_URL)
+
+        with self.assertRaises(requests.exceptions.HTTPError):
+            _ = client.fetch(CLIENT_SUPERMAN_URL)
+
+    @httpretty.activate
+    def test_fetch_post(self):
+        """Test fetch method"""
+
+        output = "success"
+
+        httpretty.register_uri(httpretty.POST,
+                               CLIENT_SPIDERMAN_URL,
+                               body=output,
+                               status=200)
+
+        client = MockedClient(CLIENT_API_URL)
+
+        response = client.fetch(CLIENT_SPIDERMAN_URL, method=HttpClient.POST)
+        self.assertEqual(response.request.method, HttpClient.POST)
+        self.assertEqual(response.text, output)
+
+    @httpretty.activate
+    def test_fetch_retry_after(self):
+        """Test whether calls returning 503, 413, 429 status codes are retried"""
+
+        retry_after_value = 1
+
+        httpretty.register_uri(httpretty.GET,
+                               CLIENT_SPIDERMAN_URL,
+                               body="",
+                               status=413,
+                               forcing_headers={
+                                   'Retry-After': str(retry_after_value)
+                               })
+
+        httpretty.register_uri(httpretty.GET,
+                               CLIENT_SUPERMAN_URL,
+                               body="",
+                               status=429,
+                               forcing_headers={
+                                   'Retry-After': str(retry_after_value)
+                               })
+
+        httpretty.register_uri(httpretty.GET,
+                               CLIENT_BATMAN_URL,
+                               body="",
+                               status=503,
+                               forcing_headers={
+                                   'Retry-After': str(retry_after_value)
+                               })
+
+        client = MockedClient(CLIENT_API_URL)
+
+        urls = [CLIENT_SPIDERMAN_URL, CLIENT_SUPERMAN_URL, CLIENT_BATMAN_URL]
+
+        for url in urls:
+            before = int(time.time())
+            expected = before + (retry_after_value * client.max_retries)
+
+            with self.assertRaises(requests.exceptions.HTTPError):
+                _ = client.fetch(url)
+
+            after = int(time.time())
+            self.assertTrue(expected <= after)
+
+    @httpretty.activate
+    def test_fetch_retry(self):
+        """Test whether calls returning redirect codes (3xx) or 408, 423, 504 are retried"""
+
+        httpretty.register_uri(httpretty.GET,
+                               CLIENT_IRONMAN_URL,
+                               body="",
+                               status=301)
+
+        httpretty.register_uri(httpretty.GET,
+                               CLIENT_SPIDERMAN_URL,
+                               body="",
+                               status=408)
+
+        httpretty.register_uri(httpretty.GET,
+                               CLIENT_SUPERMAN_URL,
+                               body="",
+                               status=423)
+
+        httpretty.register_uri(httpretty.GET,
+                               CLIENT_BATMAN_URL,
+                               body="",
+                               status=504)
+
+        errors_codes = HttpClient.DEFAULT_STATUS_FORCE_LIST
+        errors_codes.append(301)
+        client = MockedClient(CLIENT_API_URL, status_force_list=errors_codes)
+
+        urls = [CLIENT_IRONMAN_URL, CLIENT_SPIDERMAN_URL, CLIENT_SUPERMAN_URL, CLIENT_BATMAN_URL]
+
+        for url in urls:
+            with self.assertRaises(requests.exceptions.RetryError):
+                _ = client.fetch(url)
+
+
+class TestRateLimitHandler(unittest.TestCase):
+    """RateLimit handler tests"""
+
+    def test_setup_rate_limit_handler(self):
+        """Test whether variables are properly initialized during the setup"""
+
+        client = MockedClient(CLIENT_API_URL)
+
+        self.assertEqual(client.sleep_for_rate, False)
+        self.assertEqual(client.min_rate_to_sleep, RateLimitHandler.MIN_RATE_LIMIT)
+        self.assertEqual(client.rate_limit_header, RateLimitHandler.RATE_LIMIT_HEADER)
+        self.assertEqual(client.rate_limit_reset_header, RateLimitHandler.RATE_LIMIT_RESET_HEADER)
+
+        expected_sleep_for_rate = True
+        expected_min_rate_to_sleep = 200
+        expected_rate_limit_header = "ACME Corp."
+        expected_rate_limit_reset_header = "UMBRELLA Corp."
+
+        client = MockedClient(CLIENT_API_URL,
+                              sleep_for_rate=expected_sleep_for_rate,
+                              min_rate_to_sleep=expected_min_rate_to_sleep,
+                              rate_limit_header=expected_rate_limit_header,
+                              rate_limit_reset_header=expected_rate_limit_reset_header)
+
+        self.assertEqual(client.sleep_for_rate, expected_sleep_for_rate)
+        self.assertEqual(client.min_rate_to_sleep, expected_min_rate_to_sleep)
+        self.assertEqual(client.rate_limit_header, expected_rate_limit_header)
+        self.assertEqual(client.rate_limit_reset_header, expected_rate_limit_reset_header)
+
+        expected_min_rate_to_sleep = 1000
+        client = MockedClient(CLIENT_API_URL, min_rate_to_sleep=expected_min_rate_to_sleep)
+        self.assertEqual(client.min_rate_to_sleep, min(expected_min_rate_to_sleep, RateLimitHandler.MAX_RATE_LIMIT))
+
+    @httpretty.activate
+    def test_update_rate_limit(self):
+        """Test update rate limit"""
+
+        httpretty.register_uri(httpretty.GET,
+                               CLIENT_SPIDERMAN_URL,
+                               body="",
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': '15'
+                               })
+
+        httpretty.register_uri(httpretty.GET,
+                               CLIENT_SUPERMAN_URL,
+                               body="",
+                               status=200)
+
+        client = MockedClient(CLIENT_API_URL)
+        response = client.fetch(CLIENT_SPIDERMAN_URL)
+        client.update_rate_limit(response)
+
+        self.assertEqual(client.rate_limit, 20)
+        self.assertEqual(client.rate_limit_reset_ts, 15)
+
+        client = MockedClient(CLIENT_API_URL)
+        response = client.fetch(CLIENT_SUPERMAN_URL)
+        client.update_rate_limit(response)
+
+        self.assertEqual(client.rate_limit, None)
+        self.assertEqual(client.rate_limit_reset_ts, None)
+
+    @httpretty.activate
+    def test_sleep_for_rate(self):
+        """Test sleep for rate"""
+
+        reset_time = int(time.time() + 1)
+        httpretty.register_uri(httpretty.GET,
+                               CLIENT_SPIDERMAN_URL,
+                               body="",
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': str(reset_time)
+                               })
+
+        httpretty.register_uri(httpretty.GET,
+                               CLIENT_SUPERMAN_URL,
+                               body="",
+                               status=200)
+
+        client = MockedClient(CLIENT_API_URL, min_rate_to_sleep=50, sleep_for_rate=True)
+        response = client.fetch(CLIENT_SPIDERMAN_URL)
+        client.update_rate_limit(response)
+
+        client.sleep_for_rate_limit()
+
+        after = int(time.time())
+
+        self.assertTrue(reset_time + 1 == after)
+
+    @httpretty.activate
+    def test_rate_limit_error(self):
+        """Test whether the RateLimit error is raisen when sleep_for_rate is set to False"""
+
+        reset_time = 1
+        httpretty.register_uri(httpretty.GET,
+                               CLIENT_SPIDERMAN_URL,
+                               body="",
+                               status=200,
+                               forcing_headers={
+                                   'X-RateLimit-Remaining': '20',
+                                   'X-RateLimit-Reset': str(reset_time)
+                               })
+
+        httpretty.register_uri(httpretty.GET,
+                               CLIENT_SUPERMAN_URL,
+                               body="",
+                               status=200)
+
+        client = MockedClient(CLIENT_API_URL, min_rate_to_sleep=50)
+        response = client.fetch(CLIENT_SPIDERMAN_URL)
+        client.update_rate_limit(response)
+
+        with self.assertRaises(RateLimitError):
+            client.sleep_for_rate_limit()
+
+
+if __name__ == "__main__":
+    unittest.main(warnings='ignore')


### PR DESCRIPTION
This PR proposes a generic client to deal with common problems (server errors, rate limit bans, connection losts) when fetching data from APIs.