### PR TITLE
[github] Apply generic HTTP client to GitHub

### DIFF
--- a/perceval/backends/core/github.py
+++ b/perceval/backends/core/github.py
@@ -24,7 +24,6 @@
 
 import json
 import logging
-import time
 
 import requests
 
@@ -35,7 +34,8 @@ from ...backend import (Backend,
                         BackendCommand,
                         BackendCommandArgumentParser,
                         metadata)
-from ...errors import CacheError, RateLimitError
+from ...client import HttpClient, RateLimitHandler
+from ...errors import CacheError
 from ...utils import DEFAULT_DATETIME
 
 
@@ -45,6 +45,10 @@ GITHUB_API_URL = "https://api.github.com"
 # Range before sleeping until rate limit reset
 MIN_RATE_LIMIT = 10
 MAX_RATE_LIMIT = 500
+
+# Default sleep time and retries to deal with connection/server problems
+DEFAULT_SLEEP_TIME = 1
+MAX_RETRIES = 5
 
 TARGET_ISSUE_FIELDS = ['user', 'assignee', 'assignees', 'comments', 'reactions']
 
@@ -69,12 +73,13 @@ class GitHub(Backend):
     :param min_rate_to_sleep: minimun rate needed to sleep until
          it will be reset
     """
-    version = '0.11.3'
+    version = '0.12.0'
 
     def __init__(self, owner=None, repository=None,
                  api_token=None, base_url=None,
                  tag=None, cache=None,
-                 sleep_for_rate=False, min_rate_to_sleep=MIN_RATE_LIMIT):
+                 sleep_for_rate=False, min_rate_to_sleep=MIN_RATE_LIMIT,
+                 max_retries=MAX_RETRIES, default_sleep_time=DEFAULT_SLEEP_TIME):
         origin = base_url if base_url else GITHUB_URL
         origin = urijoin(origin, owner, repository)
 
@@ -83,7 +88,8 @@ class GitHub(Backend):
         self.repository = repository
         self.api_token = api_token
         self.client = GitHubClient(owner, repository, api_token, base_url,
-                                   sleep_for_rate, min_rate_to_sleep)
+                                   sleep_for_rate, min_rate_to_sleep,
+                                   max_retries, default_sleep_time)
         self._users = {}  # internal users cache
 
     @classmethod
@@ -150,7 +156,7 @@ class GitHub(Backend):
 
         from_date = datetime_to_utc(from_date)
 
-        issues_groups = self.client.issues(start=from_date)
+        issues_groups = self.client.issues(from_date=from_date)
 
         for raw_issues in issues_groups:
             self._push_cache_queue('{ISSUES}')
@@ -450,74 +456,108 @@ class GitHub(Backend):
         return found
 
 
-class GitHubClient:
+class GitHubClient(HttpClient, RateLimitHandler):
     """Client for retieving information from GitHub API"""
 
-    MAX_RETRIES = 5
     _users = {}       # users cache
     _users_orgs = {}  # users orgs cache
 
-    RATE_LIMIT_HEADER = "X-RateLimit-Remaining"
-    RATE_LIMIT_RESET_HEADER = "X-RateLimit-Reset"
-
     def __init__(self, owner, repository, token, base_url=None,
-                 sleep_for_rate=False, min_rate_to_sleep=MIN_RATE_LIMIT):
+                 sleep_for_rate=False, min_rate_to_sleep=MIN_RATE_LIMIT,
+                 default_sleep_time=DEFAULT_SLEEP_TIME, max_retries=MAX_RETRIES):
         self.owner = owner
         self.repository = repository
         self.token = token
-        self.rate_limit = None
-        self.rate_limit_reset_ts = None
-        self.sleep_for_rate = sleep_for_rate
 
         if base_url:
-            self.api_url = urijoin(base_url, 'api', 'v3')
+            base_url = urijoin(base_url, 'api', 'v3')
         else:
-            self.api_url = GITHUB_API_URL
+            base_url = GITHUB_API_URL
 
-        self.init_rate_limit(self.get_rate_limit())
+        headers = self._build_headers()
 
-        if min_rate_to_sleep > MAX_RATE_LIMIT:
-            msg = "Minimum rate to sleep value exceeded (%d)."
-            msg += "High values might cause the client to sleep forever."
-            msg += "Reset to %d."
-            logger.warning(msg, min_rate_to_sleep, MAX_RATE_LIMIT)
+        super().__init__(base_url,
+                         default_sleep_time=default_sleep_time,
+                         max_retries=max_retries, headers=headers)
+        super().setup_rate_limit_handler(sleep_for_rate=sleep_for_rate,
+                                         min_rate_to_sleep=min_rate_to_sleep)
 
-        self.min_rate_to_sleep = min(min_rate_to_sleep, MAX_RATE_LIMIT)
+        self._init_rate_limit()
 
-    def get_rate_limit(self):
-        """Get rate limit"""
+    def _build_headers(self):
+        """Set headers for session"""
 
-        url = urijoin(self.api_url, "rate_limit")
-        response = requests.get(url, headers=self.__build_headers())
-        response.raise_for_status()
+        headers = super().DEFAULT_HEADERS
+        headers.update({'Accept': 'application/vnd.github.squirrel-girl-preview'})
 
-        return response
+        if self.token:
+            headers.update({'Authorization': 'token ' + self.token})
 
-    def init_rate_limit(self, response):
-        """initialize rate_limit and rate_limit_reset_ts """
+        return headers
 
-        self.rate_limit = int(response.headers[self.RATE_LIMIT_HEADER])
-        self.rate_limit_reset_ts = int(response.headers[self.RATE_LIMIT_RESET_HEADER])
+    def _init_rate_limit(self):
+        """Initialize rate limit information"""
+
+        url = urijoin(self.base_url, "rate_limit")
+        try:
+            response = super().fetch(url)
+            self.update_rate_limit(response)
+        except requests.exceptions.HTTPError as error:
+            if error.response.status_code == 404:
+                logger.warning("Rate limit not initialized: %s", error)
+            else:
+                raise error
 
     def issue_reactions(self, issue_number):
         """Get reactions of an issue"""
 
-        return self._fetch_items("/issues/" + str(issue_number) + "/reactions", "comment")
+        payload = {
+            'per_page': 30,
+            'direction': 'asc',
+            'sort': 'updated'
+        }
+
+        path = urijoin("issues", str(issue_number), "reactions")
+        return self.fetch_items(path, payload)
 
     def issue_comment_reactions(self, comment_id):
         """Get reactions of an issue comment"""
 
-        return self._fetch_items("/issues/comments/" + str(comment_id) + "/reactions", "comment")
+        payload = {
+            'per_page': 30,
+            'direction': 'asc',
+            'sort': 'updated'
+        }
+
+        path = urijoin("issues", "comments", str(comment_id), "reactions")
+        return self.fetch_items(path, payload)
 
     def issue_comments(self, issue_number):
         """Get the issue comments from pagination"""
 
-        return self._fetch_items("/issues/" + str(issue_number) + "/comments", "comment")
+        payload = {
+            'per_page': 30,
+            'direction': 'asc',
+            'sort': 'updated'
+        }
 
-    def issues(self, start=None):
+        path = urijoin("issues", str(issue_number), "comments")
+        return self.fetch_items(path, payload)
+
+    def issues(self, from_date=None):
         """Get the issues from pagination"""
 
-        return self._fetch_items("/issues", payload_type="issue", start=start)
+        payload = {
+            'state': 'all',
+            'per_page': 30,
+            'direction': 'asc',
+            'sort': 'updated'}
+
+        if from_date:
+            payload['since'] = from_date.isoformat()
+
+        path = urijoin("issues")
+        return self.fetch_items(path, payload)
 
     def user(self, login):
         """Get the user information and update the user cache"""
@@ -527,10 +567,11 @@ class GitHubClient:
         if login in self._users:
             return self._users[login]
 
-        url_user = urijoin(self.api_url, 'users', login)
+        url_user = urijoin(self.base_url, 'users', login)
 
         logging.info("Getting info for %s" % (url_user))
-        r = self.__send_request(url_user, headers=self.__build_headers())
+
+        r = self.fetch(url_user)
         user = r.text
         self._users[login] = user
 
@@ -542,120 +583,45 @@ class GitHubClient:
         if login in self._users_orgs:
             return self._users_orgs[login]
 
-        url = urijoin(self.api_url, 'users', login, 'orgs')
+        url = urijoin(self.base_url, 'users', login, 'orgs')
         try:
-            r = self.__send_request(url, headers=self.__build_headers())
+            r = self.fetch(url)
             orgs = r.text
-        except requests.exceptions.HTTPError as ex:
+        except requests.exceptions.HTTPError as error:
             # 404 not found is wrongly received sometimes
-            if ex.response.status_code == 404:
-                logger.error("Can't get github login orgs: %s", ex)
+            if error.response.status_code == 404:
+                logger.error("Can't get github login orgs: %s", error)
                 orgs = '[]'
             else:
-                raise ex
+                raise error
 
         self._users_orgs[login] = orgs
 
         return orgs
 
-    def __get_url_repo(self):
-        """Build URL repo"""
+    def fetch(self, url, payload=None, headers=None, method=HttpClient.GET, stream=False):
+        self.sleep_for_rate_limit()
+        response = super().fetch(url, payload, headers, method, stream)
+        self.update_rate_limit(response)
 
-        github_api_repos = urijoin(self.api_url, 'repos')
-        url_repo = urijoin(github_api_repos, self.owner, self.repository)
-        return url_repo
+        return response
 
-    def __get_url(self, path, startdate=None):
-        """Build repo-"related URL"""
-
-        url = self.__get_url_repo() + path
-        return url
-
-    def __build_payload(self, payload_type='issue', startdate=None):
-        """Build payload"""
-
-        # 100 in other items. 20 for pull requests. 30 issues
-        payload = {'per_page': 30,
-                   'direction': 'asc'}
-        if payload_type == 'issue':
-            payload['state'] = 'all'
-            payload['sort'] = 'updated'
-        elif payload_type == 'comment':
-            payload['sort'] = 'updated'
-
-        if startdate:
-            startdate = startdate.isoformat()
-            payload['since'] = startdate
-        return payload
-
-    def __build_headers(self):
-        """Set header for request"""
-
-        headers = {'Accept': 'application/vnd.github.squirrel-girl-preview'}
-        if self.token:
-            headers.update({'Authorization': 'token ' + self.token})
-        return headers
-
-    def __send_request(self, url, params=None, headers=None):
-        """GET HTTP caring of rate limit"""
-
-        retries = 0
-
-        while retries < self.MAX_RETRIES:
-            try:
-                if self.rate_limit is not None and self.rate_limit <= self.min_rate_to_sleep:
-                    seconds_to_reset = self.rate_limit_reset_ts - int(time.time()) + 1
-                    cause = "GitHub rate limit exhausted."
-                    if self.sleep_for_rate:
-                        logger.info("%s Waiting %i secs for rate limit reset.", cause, seconds_to_reset)
-                        time.sleep(seconds_to_reset)
-                    else:
-                        raise RateLimitError(cause=cause, seconds_to_reset=seconds_to_reset)
-
-                r = requests.get(url, params=params, headers=headers)
-                r.raise_for_status()
-
-                # GitHub service establishes API rate limits.
-                # Enterprise version might have them deactivated.
-                if self.RATE_LIMIT_HEADER in r.headers:
-                    self.rate_limit = int(r.headers[self.RATE_LIMIT_HEADER])
-                    self.rate_limit_reset_ts = int(r.headers[self.RATE_LIMIT_RESET_HEADER])
-                    logger.debug("Rate limit: %s", self.rate_limit)
-                else:
-                    self.rate_limit = None
-                    self.rate_limit_reset_ts = None
-
-                break
-            except requests.exceptions.HTTPError as e:
-                if e.response.status_code == 403 and 'Retry-After' in r.headers:
-                    retry_seconds = int(r.headers['Retry-After'])
-                    logger.warning("Abuse rate limit, the backend will sleep for %s seconds before starting again",
-                                   retry_seconds)
-                    time.sleep(retry_seconds)
-                    retries += 1
-                else:
-                    raise e
-
-        if retries == self.MAX_RETRIES:
-            r.raise_for_status()
-
-        return r
-
-    def _fetch_items(self, path, payload_type, start=None):
+    def fetch_items(self, path, payload):
         """Return the items from github API using links pagination"""
 
         page = 0  # current page
         last_page = None  # last page
-        url_next = self.__get_url(path, start)
+        url_next = urijoin(self.base_url, 'repos', self.owner, self.repository, path)
 
         logger.debug("Get GitHub paginated items from " + url_next)
-        payload = self.__build_payload(payload_type, start)
-        r = self.__send_request(url_next, payload, self.__build_headers())
-        items = r.text
+
+        response = self.fetch(url_next, payload=payload)
+
+        items = response.text
         page += 1
 
-        if 'last' in r.links:
-            last_url = r.links['last']['url']
+        if 'last' in response.links:
+            last_url = response.links['last']['url']
             last_page = last_url.split('&page=')[1].split('&')[0]
             last_page = int(last_page)
             logger.debug("Page: %i/%i" % (page, last_page))
@@ -665,11 +631,12 @@ class GitHubClient:
 
             items = None
 
-            if 'next' in r.links:
-                url_next = r.links['next']['url']  # Loving requests :)
-                r = self.__send_request(url_next, payload, self.__build_headers())
+            if 'next' in response.links:
+                url_next = response.links['next']['url']  # Loving requests :)
+                response = self.fetch(url_next, payload=payload)
                 page += 1
-                items = r.text
+
+                items = response.text
                 logger.debug("Page: %i/%i" % (page, last_page))
 
 
@@ -696,6 +663,14 @@ class GitHubCommand(BackendCommand):
         group.add_argument('--min-rate-to-sleep', dest='min_rate_to_sleep',
                            default=MIN_RATE_LIMIT, type=int,
                            help="sleep until reset when the rate limit reaches this value")
+
+        # Generic client options
+        group.add_argument('--max-retries', dest='max_retries',
+                           default=MAX_RETRIES, type=int,
+                           help="number of API call retries")
+        group.add_argument('--default-sleep-time', dest='default_sleep_time',
+                           default=DEFAULT_SLEEP_TIME, type=int,
+                           help="sleeping time between API call retries")
 
         # Positional arguments
         parser.parser.add_argument('owner',


### PR DESCRIPTION
The generic client is applied to the GitHub backend. Now connection problems are handled in a trasparent way by the generic client.