### PR TITLE
[bugzillarest] Apply generic HTTP client to Bugzillarest

### DIFF
--- a/perceval/backends/core/bugzillarest.py
+++ b/perceval/backends/core/bugzillarest.py
@@ -33,9 +33,9 @@ from ...backend import (Backend,
                         BackendCommand,
                         BackendCommandArgumentParser,
                         metadata)
+from ...client import HttpClient
 from ...errors import BaseError, BackendError, CacheError
 from ...utils import DEFAULT_DATETIME
-from ..._version import __version__
 
 
 logger = logging.getLogger(__name__)
@@ -61,7 +61,7 @@ class BugzillaREST(Backend):
     :param tag: label used to mark the data
     :param cache: cache object to store raw data
     """
-    version = '0.5.3'
+    version = '0.6.0'
 
     def __init__(self, url, user=None, password=None, api_token=None,
                  max_bugs=MAX_BUGS, tag=None, cache=None):
@@ -295,7 +295,7 @@ class BugzillaRESTError(BaseError):
     message = "%(error)s (code: %(code)s)"
 
 
-class BugzillaRESTClient:
+class BugzillaRESTClient(HttpClient):
     """Bugzilla REST API client.
 
     This class implements a simple client to retrieve distinct
@@ -316,7 +316,6 @@ class BugzillaRESTClient:
         client
     """
     URL = "%(base)s/rest/%(resource)s"
-    HEADERS = {'User-Agent': 'Perceval/' + __version__}
 
     # API resources
     RBUG = 'bug'
@@ -343,7 +342,7 @@ class BugzillaRESTClient:
     VEXCLUDE_ATTCH_DATA = 'data'
 
     def __init__(self, base_url, user=None, password=None, api_token=None):
-        self.base_url = base_url
+        super().__init__(base_url)
         self.api_token = api_token if api_token else None
 
         if user is not None and password is not None:
@@ -461,9 +460,7 @@ class BugzillaRESTClient:
         logger.debug("Bugzilla REST client requests: %s params: %s",
                      resource, str(params))
 
-        headers = self.HEADERS
-        r = requests.get(url, headers=headers, params=params)
-        r.raise_for_status()
+        r = self.fetch(url, payload=params)
 
         # Check for possible Bugzilla API errors
         result = r.json()


### PR DESCRIPTION
The generic client is applied to the Bugzillarest backend. Now connection problems are transparently handled by the generic client.