### PR TITLE
[discourse] Apply generic HTTP client to Discourse

### DIFF
--- a/tests/test_discourse.py
+++ b/tests/test_discourse.py
@@ -563,7 +563,7 @@ class TestDiscourseClient(unittest.TestCase):
         client = DiscourseClient(DISCOURSE_SERVER_URL,
                                  api_key='aaaa')
 
-        self.assertEqual(client.url, DISCOURSE_SERVER_URL)
+        self.assertEqual(client.base_url, DISCOURSE_SERVER_URL)
         self.assertEqual(client.api_key, 'aaaa')
 
     @httpretty.activate


### PR DESCRIPTION
The generic client is applied to the Discourse backend. Now connection problems are transparently handled by the generic client.