### PR TITLE
[hyperkitty] Apply generic HTTP client to HyperKitty

### DIFF
--- a/tests/test_hyperkitty.py
+++ b/tests/test_hyperkitty.py
@@ -73,7 +73,7 @@ class TestHyperKittyList(unittest.TestCase):
         self.assertIsInstance(hkls, MailingList)
         self.assertEqual(hkls.uri, HYPERKITTY_URL)
         self.assertEqual(hkls.dirpath, self.tmp_path)
-        self.assertEqual(hkls.url, HYPERKITTY_URL)
+        self.assertEqual(hkls.client.base_url, HYPERKITTY_URL)
 
     @httpretty.activate
     @unittest.mock.patch('perceval.backends.core.hyperkitty.datetime_utcnow')


### PR DESCRIPTION
The generic client is applied to the HyperKitty backend. Now connection problems are transparently handled by the generic client.