### PR TITLE
[jira] Apply generic HTTP client to Jira

### DIFF
--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -524,7 +524,7 @@ class TestJiraClient(unittest.TestCase):
                             user='user', password='password',
                             verify=False, cert=None, max_issues=100)
 
-        self.assertEqual(client.url, 'http://example.com')
+        self.assertEqual(client.base_url, 'http://example.com')
         self.assertEqual(client.project, 'perceval')
         self.assertEqual(client.user, 'user')
         self.assertEqual(client.password, 'password')


### PR DESCRIPTION
The generic client is applied to the Jira backend. Now connection problems are transparently handled by the generic client.