### PR TITLE
[phabricator] Apply generic HTTP client to Phabricator

### DIFF
--- a/perceval/client.py
+++ b/perceval/client.py
@@ -102,7 +102,7 @@ class HttpClient:
     def __del__(self):
         self._close_http_session()
 
-    def fetch(self, url, payload=None, headers=None, method=GET, stream=False):
+    def fetch(self, url, payload=None, headers=None, method=GET, stream=False, verify=True):
         """Fetch the data from a given URL.
 
         :param url: link to the resource
@@ -110,13 +110,14 @@ class HttpClient:
         :param headers: headers of the request
         :param method: type of request call (GET or POST)
         :param stream: defer downloading the response body until the response content is available
+        :param verify: verifying the SSL certificate
 
         :returns a response object
         """
         if method == self.GET:
-            response = self.session.get(url, params=payload, headers=headers, stream=stream)
+            response = self.session.get(url, params=payload, headers=headers, stream=stream, verify=verify)
         else:
-            response = self.session.post(url, data=payload, headers=headers, stream=stream)
+            response = self.session.post(url, data=payload, headers=headers, stream=stream, verify=verify)
 
         response.raise_for_status()
 

--- a/tests/test_phabricator.py
+++ b/tests/test_phabricator.py
@@ -197,12 +197,6 @@ class TestPhabricatorBackend(unittest.TestCase):
 
         self.assertEqual(Phabricator.has_resuming(), True)
 
-    # def test_fetch_live(self):
-    #     # 'api-j44b66jfmkw6k4zisartuokr3yrg'
-    #     # 'api-vwdm7sfkdrf7yknzetdqsizr4y54'
-    #     phab = Phabricator('https://phabricator.bitergia.net', 'api-vwdm7sfkdrf7yknzetdqsizr4y54')
-    #     tasks = [task for task in phab.fetch()]
-
     @httpretty.activate
     def test_fetch(self):
         """Test whether it fetches a set of tasks"""
@@ -876,11 +870,11 @@ class TestConduitClient(unittest.TestCase):
 
         # After 4 tries (request + 3 retries) it fails
         reqs = []
-        with self.assertRaises(requests.exceptions.HTTPError):
+        with self.assertRaises(requests.exceptions.RetryError):
             _ = client.users("PHID-USER-2uk52xorcqb6sjvp467y")
             self.assertEqual(len(reqs), 4)
 
-        # After 1 trie if fails
+        # After 1 try if fails
         reqs = []
         with self.assertRaises(requests.exceptions.HTTPError):
             _ = client.phids("PHID-APPS-PhabricatorHeraldApplication")


### PR DESCRIPTION
The generic client is applied to the Phabricator backend. Now connection problems are transparently handled by the generic client. Note that the fetch method in the generic client has been extended with an additional parameter (verify) used to enable/disable SSL verification.