### PR TITLE
[meetup] Fix meetup negative sleep

### DIFF
--- a/perceval/backends/core/github.py
+++ b/perceval/backends/core/github.py
@@ -24,6 +24,7 @@
 
 import json
 import logging
+import time
 
 import requests
 
@@ -507,6 +508,13 @@ class GitHubClient(HttpClient, RateLimitHandler):
                 logger.warning("Rate limit not initialized: %s", error)
             else:
                 raise error
+
+    def calculate_time_to_reset(self):
+        """Calculate the seconds to reset the token requests, by obtaining the different
+        between the current date and the next date when the token is fully regenerated.
+        """
+
+        return self.rate_limit_reset_ts - (int(time.time()) + 1)
 
     def issue_reactions(self, issue_number):
         """Get reactions of an issue"""

--- a/perceval/backends/core/meetup.py
+++ b/perceval/backends/core/meetup.py
@@ -375,6 +375,10 @@ class MeetupClient(HttpClient, RateLimitHandler):
         super().setup_rate_limit_handler(sleep_for_rate=sleep_for_rate,
                                          min_rate_to_sleep=min_rate_to_sleep)
 
+    def calculate_time_to_reset(self):
+        """Number of seconds to wait. They are contained in the rate limit reset header"""
+        return self.rate_limit_reset_ts
+
     def events(self, group, from_date=DEFAULT_DATETIME):
         """Fetch the events pages of a given group."""
 

--- a/perceval/client.py
+++ b/perceval/client.py
@@ -197,13 +197,18 @@ class RateLimitHandler:
            raises a RateLimitError exception if sleep_for_rate flag is disabled.
         """
         if self.rate_limit is not None and self.rate_limit <= self.min_rate_to_sleep:
-            seconds_to_reset = self.rate_limit_reset_ts - int(time.time()) + 1
+            seconds_to_reset = self.calculate_time_to_reset()
             cause = "Rate limit exhausted."
             if self.sleep_for_rate:
                 logger.info("%s Waiting %i secs for rate limit reset.", cause, seconds_to_reset)
                 time.sleep(seconds_to_reset)
             else:
                 raise RateLimitError(cause=cause, seconds_to_reset=seconds_to_reset)
+
+    def calculate_time_to_reset(self):
+        """Calculate the seconds to reset the token requests."""
+
+        raise NotImplementedError
 
     def update_rate_limit(self, response):
         """Update the rate limit and the time to reset the rate limit

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -36,7 +36,6 @@ sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), ".."
 pkg_resources.declare_namespace('perceval.backends')
 
 from perceval.client import HttpClient, RateLimitHandler
-from perceval.errors import RateLimitError
 
 
 CLIENT_API_URL = "https://gateway.marvel.com/v1/"
@@ -312,37 +311,8 @@ class TestRateLimitHandler(unittest.TestCase):
         self.assertEqual(client.rate_limit_reset_ts, None)
 
     @httpretty.activate
-    def test_sleep_for_rate(self):
-        """Test sleep for rate"""
-
-        reset_time = int(time.time() + 1)
-        httpretty.register_uri(httpretty.GET,
-                               CLIENT_SPIDERMAN_URL,
-                               body="",
-                               status=200,
-                               forcing_headers={
-                                   'X-RateLimit-Remaining': '20',
-                                   'X-RateLimit-Reset': str(reset_time)
-                               })
-
-        httpretty.register_uri(httpretty.GET,
-                               CLIENT_SUPERMAN_URL,
-                               body="",
-                               status=200)
-
-        client = MockedClient(CLIENT_API_URL, min_rate_to_sleep=50, sleep_for_rate=True)
-        response = client.fetch(CLIENT_SPIDERMAN_URL)
-        client.update_rate_limit(response)
-
-        client.sleep_for_rate_limit()
-
-        after = int(time.time())
-
-        self.assertTrue(reset_time + 1 == after)
-
-    @httpretty.activate
-    def test_rate_limit_error(self):
-        """Test whether the RateLimit error is raisen when sleep_for_rate is set to False"""
+    def test_calculate_rate_limit_not_implemented(self):
+        """Test whether a NotImplemented error is raisen when calculate_rate_limit is not defined"""
 
         reset_time = 1
         httpretty.register_uri(httpretty.GET,
@@ -363,7 +333,7 @@ class TestRateLimitHandler(unittest.TestCase):
         response = client.fetch(CLIENT_SPIDERMAN_URL)
         client.update_rate_limit(response)
 
-        with self.assertRaises(RateLimitError):
+        with self.assertRaises(NotImplementedError):
             client.sleep_for_rate_limit()
 
 

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -1263,17 +1263,17 @@ class TestGitHubClient(unittest.TestCase):
         issue_2 = read_file('data/github/github_empty_request')
         rate_limit = read_file('data/github/rate_limit')
 
+        wait = 2
+        reset = int(time.time() + wait)
+
         httpretty.register_uri(httpretty.GET,
                                GITHUB_RATE_LIMIT,
                                body=rate_limit,
                                status=200,
                                forcing_headers={
                                    'X-RateLimit-Remaining': '20',
-                                   'X-RateLimit-Reset': '15'
+                                   'X-RateLimit-Reset': reset
                                })
-
-        wait = 1
-        reset = int(time.time() + wait)
 
         httpretty.register_uri(httpretty.GET,
                                GITHUB_ISSUES_URL,
@@ -1291,17 +1291,15 @@ class TestGitHubClient(unittest.TestCase):
                                status=200,
                                forcing_headers={
                                    'X-RateLimit-Remaining': '20',
-                                   'X-RateLimit-Reset': '15'
+                                   'X-RateLimit-Reset': reset
                                })
 
         client = GitHubClient("zhquan_example", "repo", "aaa", sleep_for_rate=True)
 
-        before = int(time.time())
         issues = [issues for issues in client.issues()]
         after = int(time.time())
-        dif = after - before
 
-        self.assertGreaterEqual(dif, wait)
+        self.assertTrue(reset >= after)
         self.assertEqual(len(issues), 2)
         self.assertEqual(issues[0], issue_1)
         self.assertEqual(issues[1], issue_2)

--- a/tests/test_meetup.py
+++ b/tests/test_meetup.py
@@ -779,7 +779,7 @@ class TestMeetupClient(unittest.TestCase):
         wait_to_reset = 1
 
         http_requests = setup_http_server(rate_limit=0,
-                                          reset_rate_limit=int(time.time()) + wait_to_reset)
+                                          reset_rate_limit=wait_to_reset)
 
         client = MeetupClient('aaaa', max_items=2,
                               min_rate_to_sleep=2,


### PR DESCRIPTION
This PR fixes the issue #244 by adding a new method in the generic client which calculates the time to reset needed to regenerate the token. Due to this modification, the tests of the GitHub backend have changed accordingly.