### PR TITLE
[docker] Add build-essential/gcc for dulwich

### DIFF
--- a/docker/images/master/Dockerfile
+++ b/docker/images/master/Dockerfile
@@ -4,13 +4,15 @@ MAINTAINER Alberto Martín <alberto.martin@bitergia.com>
 
 ENV GIT_URL_PERCEVAL https://github.com/grimoirelab/perceval.git
 ENV GIT_REV_PERCEVAL master
+ENV BUILD_PACKAGES build-essential
 
 # install dependencies
 
 RUN apt-get update && \
-    apt-get install -y git --no-install-recommends && \
+    apt-get install -y ${BUILD_PACKAGES} git --no-install-recommends && \
     git clone --depth 1 ${GIT_URL_PERCEVAL} -b ${GIT_REV_PERCEVAL} && \
     pip install -r perceval/requirements.txt perceval/ && \
+    apt-get remove --purge -y ${BUILD_PACKAGES} && \
     apt-get clean && \
     apt-get autoremove --purge -y && \
     find /var/lib/apt/lists -type f -delete


### PR DESCRIPTION
The dulwich build needs GCC and the docker build has been failing since it was added as a requirement.