### PR TITLE
[http-client] Fix class attributes

### DIFF
--- a/perceval/backends/core/github.py
+++ b/perceval/backends/core/github.py
@@ -74,7 +74,7 @@ class GitHub(Backend):
     :param min_rate_to_sleep: minimun rate needed to sleep until
          it will be reset
     """
-    version = '0.12.0'
+    version = '0.12.1'
 
     def __init__(self, owner=None, repository=None,
                  api_token=None, base_url=None,
@@ -475,20 +475,16 @@ class GitHubClient(HttpClient, RateLimitHandler):
         else:
             base_url = GITHUB_API_URL
 
-        headers = self._build_headers()
-
-        super().__init__(base_url,
-                         default_sleep_time=default_sleep_time,
-                         max_retries=max_retries, headers=headers)
-        super().setup_rate_limit_handler(sleep_for_rate=sleep_for_rate,
-                                         min_rate_to_sleep=min_rate_to_sleep)
+        super().__init__(base_url, default_sleep_time=default_sleep_time, max_retries=max_retries,
+                         extra_headers=self._set_extra_headers())
+        super().setup_rate_limit_handler(sleep_for_rate=sleep_for_rate, min_rate_to_sleep=min_rate_to_sleep)
 
         self._init_rate_limit()
 
-    def _build_headers(self):
-        """Set headers for session"""
+    def _set_extra_headers(self):
+        """Set extra headers for session"""
 
-        headers = super().DEFAULT_HEADERS
+        headers = {}
         headers.update({'Accept': 'application/vnd.github.squirrel-girl-preview'})
 
         if self.token:

--- a/perceval/backends/core/jenkins.py
+++ b/perceval/backends/core/jenkins.py
@@ -197,9 +197,7 @@ class JenkinsClient(HttpClient):
     MAX_RETRIES = 5
 
     def __init__(self, url, blacklist_jobs=None, sleep_time=SLEEP_TIME):
-        status_codes = list(HttpClient.DEFAULT_STATUS_FORCE_LIST)
-        status_codes.extend([410, 502, 503])
-        super().__init__(url, default_sleep_time=sleep_time, status_forcelist=status_codes)
+        super().__init__(url, default_sleep_time=sleep_time, extra_status_forcelist=[410, 502, 503])
         self.blacklist_jobs = blacklist_jobs
 
     def get_jobs(self):

--- a/perceval/backends/core/meetup.py
+++ b/perceval/backends/core/meetup.py
@@ -68,7 +68,7 @@ class Meetup(Backend):
     :param sleep_time: minimun waiting time to avoid too many request
          exception
     """
-    version = '0.6.0'
+    version = '0.6.1'
 
     def __init__(self, group, api_token, max_items=MAX_ITEMS,
                  tag=None, cache=None,
@@ -368,12 +368,8 @@ class MeetupClient(HttpClient, RateLimitHandler):
         self.api_key = api_key
         self.max_items = max_items
 
-        status_list = HttpClient.DEFAULT_STATUS_FORCE_LIST
-        status_list.append(429)
-        super().__init__(MEETUP_API_URL,
-                         default_sleep_time=sleep_time, status_forcelist=status_list)
-        super().setup_rate_limit_handler(sleep_for_rate=sleep_for_rate,
-                                         min_rate_to_sleep=min_rate_to_sleep)
+        super().__init__(MEETUP_API_URL, default_sleep_time=sleep_time, extra_status_forcelist=[429])
+        super().setup_rate_limit_handler(sleep_for_rate=sleep_for_rate, min_rate_to_sleep=min_rate_to_sleep)
 
     def calculate_time_to_reset(self):
         """Number of seconds to wait. They are contained in the rate limit reset header"""

--- a/perceval/backends/core/phabricator.py
+++ b/perceval/backends/core/phabricator.py
@@ -49,7 +49,7 @@ class Phabricator(Backend):
     :param tag: label used to mark the data
     :param cache: cache object to store raw data
     """
-    version = '0.6.0'
+    version = '0.6.1'
 
     def __init__(self, url, api_token, tag=None, cache=None):
         origin = url
@@ -521,10 +521,7 @@ class ConduitClient(HttpClient):
     VOUTDATED = 'outdated'
 
     def __init__(self, base_url, api_token):
-        status_list = HttpClient.DEFAULT_STATUS_FORCE_LIST
-        status_list.extend([502, 503])
-        super().__init__(base_url.rstrip('/'), max_retries=3,
-                         status_forcelist=status_list)
+        super().__init__(base_url.rstrip('/'), max_retries=3, extra_status_forcelist=[502, 503])
         self.api_token = api_token
 
     def tasks(self, from_date=DEFAULT_DATETIME):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -47,15 +47,19 @@ CLIENT_IRONMAN_URL = "https://gateway.marvel.com/v1/public/characters/4"
 
 class MockedClient(HttpClient, RateLimitHandler):
 
-    def __init__(self, base_url, default_sleep_time=0.1, max_retries=1,
-                 status_force_list=HttpClient.DEFAULT_STATUS_FORCE_LIST,
-                 headers=HttpClient.DEFAULT_HEADERS, sleep_for_rate=False,
+    def __init__(self, base_url, default_sleep_time=HttpClient.DEFAULT_SLEEP_TIME,
+                 max_retries=HttpClient.MAX_RETRIES,
+                 extra_status_forcelist=None,
+                 extra_retry_after_status=None,
+                 extra_headers=HttpClient.DEFAULT_HEADERS, sleep_for_rate=False,
                  min_rate_to_sleep=RateLimitHandler.MIN_RATE_LIMIT,
                  rate_limit_header=RateLimitHandler.RATE_LIMIT_HEADER,
                  rate_limit_reset_header=RateLimitHandler.RATE_LIMIT_RESET_HEADER):
 
         super().__init__(base_url, default_sleep_time=default_sleep_time, max_retries=max_retries,
-                         status_forcelist=status_force_list, headers=headers)
+                         extra_status_forcelist=extra_status_forcelist,
+                         extra_retry_after_status=extra_retry_after_status,
+                         extra_headers=extra_headers)
         super().setup_rate_limit_handler(sleep_for_rate=sleep_for_rate,
                                          min_rate_to_sleep=min_rate_to_sleep,
                                          rate_limit_header=rate_limit_header,
@@ -68,42 +72,47 @@ class TestHttpClient(unittest.TestCase):
     def test_initialization(self):
         """Test whether attributes are initializated"""
 
-        expected_retries = 5
-        expected_sleep_time = 100
-        expected_headers = {'User-Agent': 'ACME Corp.'}
-
-        client = MockedClient(CLIENT_API_URL,
-                              max_retries=expected_retries,
-                              default_sleep_time=expected_sleep_time,
-                              headers=expected_headers)
+        client = MockedClient(CLIENT_API_URL)
 
         self.assertEqual(client.base_url, CLIENT_API_URL)
-        self.assertEqual(client.max_retries, expected_retries)
+        self.assertEqual(client.max_retries, HttpClient.MAX_RETRIES)
         self.assertEqual(client.max_retries_on_connect, HttpClient.MAX_RETRIES_ON_CONNECT)
         self.assertEqual(client.max_retries_on_read, HttpClient.MAX_RETRIES_ON_READ)
         self.assertEqual(client.max_retries_on_redirect, HttpClient.MAX_RETRIES_ON_REDIRECT)
         self.assertEqual(client.max_retries_on_read, HttpClient.MAX_RETRIES_ON_READ)
         self.assertEqual(client.max_retries_on_status, HttpClient.MAX_RETRIES_ON_STATUS)
         self.assertEqual(client.status_forcelist, HttpClient.DEFAULT_STATUS_FORCE_LIST)
+        self.assertEqual(client.retry_after_status, HttpClient.DEFAULT_RETRY_AFTER_STATUS_CODES)
         self.assertEqual(client.method_whitelist, HttpClient.DEFAULT_METHOD_WHITELIST)
         self.assertEqual(client.raise_on_redirect, HttpClient.DEFAULT_RAISE_ON_REDIRECT)
         self.assertEqual(client.raise_on_status, HttpClient.DEFAULT_RAISE_ON_STATUS)
         self.assertEqual(client.respect_retry_after_header, HttpClient.DEFAULT_RESPECT_RETRY_AFTER_HEADER)
-        self.assertEqual(client.default_sleep_time, expected_sleep_time)
+        self.assertEqual(client.default_sleep_time, HttpClient.DEFAULT_SLEEP_TIME)
 
         self.assertIsNotNone(client.session)
-        self.assertEqual(client.session.headers['User-Agent'], expected_headers.get('User-Agent'))
+        self.assertEqual(client.session.headers['User-Agent'], HttpClient.DEFAULT_HEADERS.get('User-Agent'))
 
         self.assertEqual(client.rate_limit, None)
         self.assertEqual(client.rate_limit_reset_ts, None)
 
-        client = MockedClient(CLIENT_API_URL,
-                              max_retries=HttpClient.MAX_RETRIES,
-                              default_sleep_time=HttpClient.DEFAULT_SLEEP_TIME)
+        expected_retries = 5
+        expected_sleep_time = 100
+        expected_headers = {'User-Agent': 'ACME Corp.', 'Token': "your-token"}
+        extra_status = 555
 
-        self.assertEqual(client.session.headers['User-Agent'], HttpClient.DEFAULT_HEADERS.get('User-Agent'))
-        self.assertEqual(client.max_retries, HttpClient.MAX_RETRIES)
-        self.assertEqual(client.default_sleep_time, HttpClient.DEFAULT_SLEEP_TIME)
+        client = MockedClient(CLIENT_API_URL,
+                              max_retries=expected_retries,
+                              default_sleep_time=expected_sleep_time,
+                              extra_headers=expected_headers,
+                              extra_retry_after_status=[extra_status],
+                              extra_status_forcelist=[extra_status])
+
+        self.assertEqual(client.session.headers['User-Agent'], expected_headers.get('User-Agent'))
+        self.assertEqual(client.session.headers['Token'], expected_headers.get('Token'))
+        self.assertEqual(client.max_retries, expected_retries)
+        self.assertEqual(client.default_sleep_time, expected_sleep_time)
+        self.assertTrue(extra_status in client.status_forcelist)
+        self.assertTrue(extra_status in client.retry_after_status)
 
     @httpretty.activate
     def test_close_session(self):
@@ -129,7 +138,7 @@ class TestHttpClient(unittest.TestCase):
                                body=output,
                                status=200)
 
-        client = MockedClient(CLIENT_API_URL)
+        client = MockedClient(CLIENT_API_URL, default_sleep_time=0.1, max_retries=1)
         response = client.fetch(CLIENT_SPIDERMAN_URL)
 
         self.assertEqual(response.request.method, HttpClient.GET)
@@ -144,7 +153,7 @@ class TestHttpClient(unittest.TestCase):
                                body="",
                                status=403)
 
-        client = MockedClient(CLIENT_API_URL)
+        client = MockedClient(CLIENT_API_URL, default_sleep_time=0.1, max_retries=1)
 
         with self.assertRaises(requests.exceptions.HTTPError):
             _ = client.fetch(CLIENT_SUPERMAN_URL)
@@ -160,7 +169,7 @@ class TestHttpClient(unittest.TestCase):
                                body=output,
                                status=200)
 
-        client = MockedClient(CLIENT_API_URL)
+        client = MockedClient(CLIENT_API_URL, default_sleep_time=0.1, max_retries=1)
 
         response = client.fetch(CLIENT_SPIDERMAN_URL, method=HttpClient.POST)
         self.assertEqual(response.request.method, HttpClient.POST)
@@ -196,7 +205,7 @@ class TestHttpClient(unittest.TestCase):
                                    'Retry-After': str(retry_after_value)
                                })
 
-        client = MockedClient(CLIENT_API_URL)
+        client = MockedClient(CLIENT_API_URL, default_sleep_time=0.1, max_retries=1)
 
         urls = [CLIENT_SPIDERMAN_URL, CLIENT_SUPERMAN_URL, CLIENT_BATMAN_URL]
 
@@ -234,9 +243,7 @@ class TestHttpClient(unittest.TestCase):
                                body="",
                                status=504)
 
-        errors_codes = HttpClient.DEFAULT_STATUS_FORCE_LIST
-        errors_codes.append(301)
-        client = MockedClient(CLIENT_API_URL, status_force_list=errors_codes)
+        client = MockedClient(CLIENT_API_URL, default_sleep_time=0.1, max_retries=1, extra_status_forcelist=[301])
 
         urls = [CLIENT_IRONMAN_URL, CLIENT_SPIDERMAN_URL, CLIENT_SUPERMAN_URL, CLIENT_BATMAN_URL]
 
@@ -251,7 +258,7 @@ class TestRateLimitHandler(unittest.TestCase):
     def test_setup_rate_limit_handler(self):
         """Test whether variables are properly initialized during the setup"""
 
-        client = MockedClient(CLIENT_API_URL)
+        client = MockedClient(CLIENT_API_URL, default_sleep_time=0.1, max_retries=1)
 
         self.assertEqual(client.sleep_for_rate, False)
         self.assertEqual(client.min_rate_to_sleep, RateLimitHandler.MIN_RATE_LIMIT)
@@ -263,7 +270,7 @@ class TestRateLimitHandler(unittest.TestCase):
         expected_rate_limit_header = "ACME Corp."
         expected_rate_limit_reset_header = "UMBRELLA Corp."
 
-        client = MockedClient(CLIENT_API_URL,
+        client = MockedClient(CLIENT_API_URL, default_sleep_time=0.1, max_retries=1,
                               sleep_for_rate=expected_sleep_for_rate,
                               min_rate_to_sleep=expected_min_rate_to_sleep,
                               rate_limit_header=expected_rate_limit_header,
@@ -275,7 +282,8 @@ class TestRateLimitHandler(unittest.TestCase):
         self.assertEqual(client.rate_limit_reset_header, expected_rate_limit_reset_header)
 
         expected_min_rate_to_sleep = 1000
-        client = MockedClient(CLIENT_API_URL, min_rate_to_sleep=expected_min_rate_to_sleep)
+        client = MockedClient(CLIENT_API_URL, min_rate_to_sleep=expected_min_rate_to_sleep,
+                              default_sleep_time=0.1, max_retries=1)
         self.assertEqual(client.min_rate_to_sleep, min(expected_min_rate_to_sleep, RateLimitHandler.MAX_RATE_LIMIT))
 
     @httpretty.activate
@@ -296,14 +304,14 @@ class TestRateLimitHandler(unittest.TestCase):
                                body="",
                                status=200)
 
-        client = MockedClient(CLIENT_API_URL)
+        client = MockedClient(CLIENT_API_URL, default_sleep_time=0.1, max_retries=1)
         response = client.fetch(CLIENT_SPIDERMAN_URL)
         client.update_rate_limit(response)
 
         self.assertEqual(client.rate_limit, 20)
         self.assertEqual(client.rate_limit_reset_ts, 15)
 
-        client = MockedClient(CLIENT_API_URL)
+        client = MockedClient(CLIENT_API_URL, default_sleep_time=0.1, max_retries=1)
         response = client.fetch(CLIENT_SUPERMAN_URL)
         client.update_rate_limit(response)
 
@@ -329,7 +337,7 @@ class TestRateLimitHandler(unittest.TestCase):
                                body="",
                                status=200)
 
-        client = MockedClient(CLIENT_API_URL, min_rate_to_sleep=50)
+        client = MockedClient(CLIENT_API_URL, min_rate_to_sleep=50, default_sleep_time=0.1, max_retries=1)
         response = client.fetch(CLIENT_SPIDERMAN_URL)
         client.update_rate_limit(response)
 


### PR DESCRIPTION
This patch fixes the initialization of headers and status codes (forcelist and retry after status). Before they were initialized by references, causing side effects in several tests (launchpad, github, etc.). Now, they are initialized by value.
Some backends have been modified according to the new http-client parameters.