### PR TITLE
[archive] Add archive

### DIFF
--- a/perceval/archive.py
+++ b/perceval/archive.py
@@ -1,0 +1,344 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2017 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA.
+#
+# Authors:
+#     Valerio Cosentino <valcos@bitergia.com>
+#     Santiago Dueñas <sduenas@bitergia.com>
+#
+
+import hashlib
+import json
+import logging
+import os
+import pickle
+import sqlite3
+
+from grimoirelab.toolkit.datetime import (datetime_utcnow,
+                                          datetime_to_utc,
+                                          str_to_datetime)
+
+from .errors import ArchiveError
+
+
+logger = logging.getLogger(__name__)
+
+
+class Archive:
+    """Basic class for archiving raw items fetched by Perceval.
+
+    This class allows to archive raw items - usually HTML pages or
+    JSON documents - for a further recovery. These raw items will
+    be fetched, stored and retrieved back by a backend.
+
+    Each stored item will have a hash code used as unique identifier.
+    Hash codes are generated using URIs and other parameters needed
+    to fetch raw items.
+
+    When an instance of `Archive` is initialized it will expect
+    to access an existing archive file. To create a new and empty
+    archive used `create` class method instead. Metadata must be
+    initialized calling to `init_metadata` method after creating
+    a new archive.
+
+    :param archive_path: path where this archive is stored
+
+    :raises ArchiveError: when the archive does not exist or is invalid
+    """
+
+    ARCHIVE_TABLE = "archive"
+    METADATA_TABLE = "metadata"
+
+    # Table structure
+    ARCHIVE_CREATE_STMT = "CREATE TABLE " + ARCHIVE_TABLE + " ( " \
+                          "id INTEGER PRIMARY KEY AUTOINCREMENT, " \
+                          "hashcode VARCHAR(256) UNIQUE NOT NULL, " \
+                          "uri TEXT, " \
+                          "payload BLOB, " \
+                          "headers BLOB, " \
+                          "data BLOB)"
+
+    METADATA_CREATE_STMT = "CREATE TABLE " + METADATA_TABLE + " ( " \
+                           "origin TEXT, " \
+                           "backend_name TEXT, " \
+                           "backend_version TEXT, " \
+                           "item_category TEXT, " \
+                           "backend_params BLOB, " \
+                           "created_on TEXT)"
+
+    def __init__(self, archive_path):
+        if not os.path.exists(archive_path):
+            raise ArchiveError(cause="archive %s does not exist" % (archive_path))
+
+        self.archive_path = archive_path
+        self.origin = None
+        self.backend_name = None
+        self.backend_version = None
+        self.item_category = None
+        self.backend_params = None
+        self.created_on = None
+
+        self._db = sqlite3.connect(self.archive_path)
+
+        self._verify_archive()
+        self._load_metadata()
+
+    def __del__(self):
+        conn = getattr(self, '_db', None)
+        if conn:
+            conn.close()
+
+    def init_metadata(self, origin, backend_name, backend_version,
+                      item_category, backend_params):
+        """Init metadata information.
+
+        Metatada is composed by basic information needed to identify
+        where archived data came from and how it can be retrieved
+        and built into Perceval items.
+
+        :param: origin: identifier of the repository
+        :param: backend_name: name of the backend
+        :param: backend_version: version of the backend
+        :param: item_category: category of the items fetched
+        :param: backend_params: dict representation of the fetch parameters
+
+        raises ArchiveError: when an error occurs initializing the metadata
+        """
+        created_on = datetime_to_utc(datetime_utcnow())
+        created_on_dumped = created_on.isoformat()
+        backend_params_dumped = pickle.dumps(backend_params, 0)
+
+        metadata = (origin, backend_name, backend_version, item_category,
+                    backend_params_dumped, created_on_dumped,)
+
+        try:
+            cursor = self._db.cursor()
+            insert_stmt = "INSERT INTO " + self.METADATA_TABLE + " "\
+                          "(origin, backend_name, backend_version, " \
+                          "item_category, backend_params, created_on) " \
+                          "VALUES (?, ?, ?, ?, ?, ?)"
+            cursor.execute(insert_stmt, metadata)
+
+            self._db.commit()
+            cursor.close()
+        except sqlite3.DatabaseError as e:
+            msg = "metadata initialization error; cause: %s" % str(e)
+            raise ArchiveError(cause=msg)
+
+        self.origin = origin
+        self.backend_name = backend_name
+        self.backend_version = backend_version
+        self.item_category = item_category
+        self.backend_params = backend_params
+        self.created_on = created_on
+
+        logger.debug("Metadata of archive %s initialized to %s",
+                     self.archive_path, metadata)
+
+    def store(self, uri, payload, headers, data):
+        """Store a raw item in this archive.
+
+        The method will store `data` content in this archive. The unique
+        identifier for that item will be generated using the rest of the
+        parameters.
+
+        :param uri: request URI
+        :param payload: request payload
+        :param headers: request headers
+        :param data: data to store in this archive
+
+        :raises ArchiveError: when an error occurs storing the given data
+        """
+        hashcode = self.make_hashcode(uri, payload, headers)
+        payload_dump = pickle.dumps(payload, 0)
+        headers_dump = pickle.dumps(headers, 0)
+        data_dump = pickle.dumps(data, 0)
+
+        logger.debug("Archiving %s with %s %s %s in %s",
+                     hashcode, uri, payload, headers, self.archive_path)
+
+        try:
+            cursor = self._db.cursor()
+            insert_stmt = "INSERT INTO " + self.ARCHIVE_TABLE + " (" \
+                          "id, hashcode, uri, payload, headers, data) " \
+                          "VALUES(?,?,?,?,?,?)"
+            cursor.execute(insert_stmt, (None, hashcode, uri,
+                                         payload_dump, headers_dump, data_dump))
+            self._db.commit()
+            cursor.close()
+        except sqlite3.IntegrityError as e:
+            msg = "data storage error; cause: duplicated entry %s" % hashcode
+            raise ArchiveError(cause=msg)
+        except sqlite3.DatabaseError as e:
+            msg = "data storage error; cause: %s" % str(e)
+            raise ArchiveError(cause=msg)
+
+        logger.debug("%s data archived in %s", hashcode, self.archive_path)
+
+    def retrieve(self, uri, payload, headers):
+        """Retrieve a raw item from the archive.
+
+        The method will return the `data` content corresponding to the
+        hascode derived from the given parameters.
+
+        :param uri: request URI
+        :param payload: request payload
+        :param headers: request headers
+
+        :returns: the archived data
+
+        :raises ArchiveError: when an error occurs retrieving data
+        """
+        hashcode = self.make_hashcode(uri, payload, headers)
+
+        logger.debug("Retrieving entry %s with %s %s %s in %s",
+                     hashcode, uri, payload, headers, self.archive_path)
+
+        self._db.row_factory = sqlite3.Row
+
+        try:
+            cursor = self._db.cursor()
+            select_stmt = "SELECT data " \
+                          "FROM " + self.ARCHIVE_TABLE + " " \
+                          "WHERE hashcode = ?"
+            cursor.execute(select_stmt, (hashcode,))
+            row = cursor.fetchone()
+            cursor.close()
+        except sqlite3.DatabaseError as e:
+            msg = "data retrieval error; cause: %s" % str(e)
+            raise ArchiveError(cause=msg)
+
+        if row:
+            found = pickle.loads(row['data'])
+        else:
+            msg = "entry %s not found in archive %s" % (hashcode, self.archive_path)
+            raise ArchiveError(cause=msg)
+
+        return found
+
+    @classmethod
+    def create(cls, archive_path):
+        """Create a brand new archive.
+
+         Call this method to create a new and empty archive. It will initialize
+         the storage file in the path defined by `archive_path`.
+
+        :param archive_path: absolute path where the archive file will be created
+
+        :raises ArchiveError: when the archive file already exists
+        """
+        if os.path.exists(archive_path):
+            msg = "archive %s already exists; remove it before creating a new one"
+            raise ArchiveError(cause=msg % (archive_path))
+
+        conn = sqlite3.connect(archive_path)
+
+        cursor = conn.cursor()
+        cursor.execute(cls.METADATA_CREATE_STMT)
+        cursor.execute(cls.ARCHIVE_CREATE_STMT)
+        conn.commit()
+
+        cursor.close()
+        conn.close()
+
+        logger.debug("Creating archive %s", archive_path)
+        archive = cls(archive_path)
+        logger.debug("Achive %s was created", archive_path)
+
+        return archive
+
+    @staticmethod
+    def make_hashcode(uri, payload, headers):
+        """Generate a SHA1 based on the given arguments.
+
+        Hashcodes created by this method will used as unique identifiers
+        for the raw items or resources stored by this archive.
+
+        :param uri: URI to the resource
+        :param payload: payload of the request needed to fetch the resource
+        :param headers: headers of the request needed to fetch the resource
+
+        :returns: a SHA1 hash code
+        """
+        def dict_to_json_str(data):
+            return json.dumps(data, sort_keys=True)
+
+        content = ':'.join([uri, dict_to_json_str(payload), dict_to_json_str(headers)])
+        hashcode = hashlib.sha1(content.encode('utf-8'))
+        return hashcode.hexdigest()
+
+    def _verify_archive(self):
+        """Check whether the archive is valid or not.
+
+        This method will check if tables were created and if they
+        contain valid data.
+        """
+        nentries = self._count_table_rows(self.ARCHIVE_TABLE)
+        nmetadata = self._count_table_rows(self.METADATA_TABLE)
+
+        if nmetadata > 1:
+            msg = "archive %s metadata corrupted; multiple metadata entries" % (self.archive_path)
+            raise ArchiveError(cause=msg)
+        if nmetadata == 0 and nentries > 0:
+            msg = "archive %s metadata is empty but %s entries were achived" % (self.archive_path)
+            raise ArchiveError(cause=msg)
+
+        logger.debug("Integrity of archive %s OK; entries: %s rows, metadata: %s rows",
+                     self.archive_path, nentries, nmetadata)
+
+    def _load_metadata(self):
+        """Load metadata from the archive file"""
+
+        logger.debug("Loading metadata infomation of archive %s", self.archive_path)
+
+        cursor = self._db.cursor()
+        select_stmt = "SELECT origin, backend_name, backend_version, " \
+                      "item_category, backend_params, created_on " \
+                      "FROM " + self.METADATA_TABLE + " " \
+                      "LIMIT 1"
+        cursor.execute(select_stmt)
+        row = cursor.fetchone()
+        cursor.close()
+
+        if row:
+            self.origin = row[0]
+            self.backend_name = row[1]
+            self.backend_version = row[2]
+            self.item_category = row[3]
+            self.backend_params = pickle.loads(row[4])
+            self.created_on = str_to_datetime(row[5])
+        else:
+            logger.debug("Metadata of archive %s was empty", self.archive_path)
+
+        logger.debug("Metadata of archive %s loaded", self.archive_path)
+
+    def _count_table_rows(self, table_name):
+        """Fetch the number of rows in a table"""
+
+        cursor = self._db.cursor()
+        select_stmt = "SELECT COUNT(*) FROM " + table_name
+
+        try:
+            cursor.execute(select_stmt)
+            row = cursor.fetchone()
+        except sqlite3.DatabaseError as e:
+            msg = "invalid archive file; cause: %s" % str(e)
+            raise ArchiveError(cause=msg)
+        finally:
+            cursor.close()
+
+        return row[0]

--- a/perceval/backend.py
+++ b/perceval/backend.py
@@ -33,9 +33,10 @@ from datetime import datetime as dt
 from grimoirelab.toolkit.introspect import find_signature_parameters
 from grimoirelab.toolkit.datetime import str_to_datetime
 
-from ._version import __version__
+from .archive import Archive
 from .cache import Cache, setup_cache
 from .utils import DEFAULT_DATETIME
+from ._version import __version__
 
 
 class Backend:
@@ -61,18 +62,20 @@ class Backend:
 
     :param origin: identifier of the repository
     :param tag: tag items using this label
-    :param cache: object to cache raw data
+    :param cache: object to caeche raw data
+    :param archive: archive object from where fetch the archived data
 
     :raises ValueError: raised when `cache` is not an instance of
         `Cache` class
     """
     version = '0.5'
 
-    def __init__(self, origin, tag=None, cache=None):
+    def __init__(self, origin, tag=None, cache=None, archive=None):
         self._origin = origin
         self.tag = tag if tag else origin
         self.cache = cache or None
         self.cache_queue = []
+        self.archive = archive or None
 
     @property
     def origin(self):
@@ -90,6 +93,18 @@ class Backend:
             raise ValueError(msg)
 
         self._cache = obj
+
+    @ property
+    def archive(self):
+        return self._archive
+
+    @ archive.setter
+    def archive(self, obj):
+        if obj and not isinstance(obj, Archive):
+            msg = "obj is not an instance of Archive. %s object given" % (str(type(obj)))
+            raise ValueError(msg)
+
+        self._archive = obj
 
     def fetch(self, from_date=DEFAULT_DATETIME):
         raise NotImplementedError

--- a/perceval/errors.py
+++ b/perceval/errors.py
@@ -43,6 +43,12 @@ class BackendError(BaseError):
     message = "%(cause)s"
 
 
+class ArchiveError(BaseError):
+    """Generic error for archive objects"""
+
+    message = "%(cause)s"
+
+
 class CacheError(BaseError):
     """Generic error for cache objects"""
 

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2017 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA.
+#
+# Authors:
+#     Valerio Cosentino <valcos@bitergia.com>
+#     Santiago Dueñas <sduenas@bitergia.com>
+#
+
+import os
+import pickle
+import shutil
+import sqlite3
+import sys
+import tempfile
+import unittest.mock
+
+import httpretty
+import requests
+
+from grimoirelab.toolkit.datetime import datetime_utcnow, datetime_to_utc
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), ".."))
+
+from perceval.archive import Archive
+from perceval.errors import ArchiveError
+
+
+def count_number_rows(db, table_name):
+    conn = sqlite3.connect(db)
+    cursor = conn.cursor()
+    cursor.execute("SELECT COUNT(*) FROM " + table_name)
+    nrows = cursor.fetchone()[0]
+    cursor.close()
+    return nrows
+
+
+class TestArchive(unittest.TestCase):
+    """Archive tests"""
+
+    def setUp(self):
+        self.test_path = tempfile.mkdtemp(prefix='perceval_')
+
+    def tearDown(self):
+        shutil.rmtree(self.test_path)
+
+    def test_create(self):
+        """Test a new an empty archive is created"""
+
+        archive_path = os.path.join(self.test_path, 'myarchive')
+        archive = Archive.create(archive_path)
+
+        # Archive file was created
+        self.assertEqual(archive.archive_path, archive_path)
+        self.assertEqual(os.path.exists(archive.archive_path), True)
+
+        # Properties are initialized
+        self.assertEqual(archive.created_on, None)
+        self.assertEqual(archive.origin, None)
+        self.assertEqual(archive.backend_name, None)
+        self.assertEqual(archive.backend_version, None)
+        self.assertEqual(archive.item_category, None)
+        self.assertEqual(archive.backend_params, None)
+
+        # Tables are empty
+        nrows = count_number_rows(archive_path, Archive.ARCHIVE_TABLE)
+        self.assertEqual(nrows, 0)
+
+        nrows = count_number_rows(archive_path, Archive.METADATA_TABLE)
+        self.assertEqual(nrows, 0)
+
+    def test_create_existing_archive(self):
+        """Test if create method fails when the given archive path already exists"""
+
+        archive_path = os.path.join(self.test_path, 'myarchive')
+        Archive.create(archive_path)
+
+        with self.assertRaisesRegex(ArchiveError, "archive %s already exists" % archive_path):
+            Archive.create(archive_path)
+
+    def test_init(self):
+        """Test whether an archive is propertly initialized"""
+
+        archive_path = os.path.join(self.test_path, 'myarchive')
+        _ = Archive.create(archive_path)
+
+        archive = Archive(archive_path)
+        self.assertEqual(archive.archive_path, archive_path)
+        self.assertEqual(archive.created_on, None)
+        self.assertEqual(archive.origin, None)
+        self.assertEqual(archive.backend_name, None)
+        self.assertEqual(archive.backend_version, None)
+        self.assertEqual(archive.item_category, None)
+        self.assertEqual(archive.backend_params, None)
+
+    def test_init_not_existing_archive(self):
+        """Test if an exception is raised when the given archive does not exist"""
+
+        archive_path = os.path.join(self.test_path, 'myarchive')
+
+        with self.assertRaisesRegex(ArchiveError, "archive %s does not exist" % archive_path):
+            _ = Archive(archive_path)
+
+    def test_init_not_valid_archive(self):
+        """Test if an exception is raised when the file is an invalid archive"""
+
+        archive_path = os.path.join(self.test_path, 'invalid_archive')
+
+        with open(archive_path, 'w') as fd:
+            fd.write("Invalid archive file")
+
+        with self.assertRaisesRegex(ArchiveError, "invalid archive file"):
+            _ = Archive(archive_path)
+
+    def test_init_metadata(self):
+        """Test whether metadata information is properly initialized"""
+
+        archive_path = os.path.join(self.test_path, 'myarchive')
+        archive = Archive.create(archive_path)
+
+        before_dt = datetime_to_utc(datetime_utcnow())
+        archive.init_metadata('marvel.com', 'marvel-comics-backend', '0.1.0',
+                              'issue', {'from_date': before_dt})
+        after_dt = datetime_to_utc(datetime_utcnow())
+
+        archive_copy = Archive(archive_path)
+
+        # Both copies should have the same parameters
+        for arch in [archive, archive_copy]:
+            self.assertEqual(arch.origin, 'marvel.com')
+            self.assertEqual(arch.backend_name, 'marvel-comics-backend')
+            self.assertEqual(arch.backend_version, '0.1.0')
+            self.assertEqual(arch.item_category, 'issue')
+            self.assertGreaterEqual(arch.created_on, before_dt)
+            self.assertLessEqual(arch.created_on, after_dt)
+            self.assertDictEqual(arch.backend_params, {'from_date': before_dt})
+
+    @httpretty.activate
+    def test_store(self):
+        """Test whether data is properly stored in the archive"""
+
+        data_requests = [
+            ("https://example.com/", {'q': 'issues', 'date': '2017-01-10'}, {}),
+            ("https://example.com/", {'q': 'issues', 'date': '2018-01-01'}, {}),
+            ("https://example.com/tasks", {'task_id': 10}, {'Accept': 'application/json'}),
+        ]
+
+        httpretty.register_uri(httpretty.GET,
+                               "https://example.com/",
+                               body='{"hey": "there"}',
+                               status=200)
+        httpretty.register_uri(httpretty.GET,
+                               "https://example.com/tasks",
+                               body='{"task": "my task"}',
+                               status=200)
+
+        archive_path = os.path.join(self.test_path, 'myarchive')
+        archive = Archive.create(archive_path)
+
+        # Store data in the archive
+        responses = []
+
+        for dr in data_requests:
+            response = requests.get(dr[0], params=dr[1], headers=dr[2])
+            archive.store(dr[0], dr[1], dr[2], response)
+            responses.append(response)
+
+        db = sqlite3.connect(archive.archive_path)
+        cursor = db.cursor()
+        cursor.execute("SELECT hashcode, data, uri, payload, headers FROM archive")
+        data_stored = cursor.fetchall()
+        cursor.close()
+
+        self.assertEqual(len(data_stored), len(data_requests))
+
+        ds = data_stored[0]
+        dr = data_requests[0]
+        self.assertEqual(ds[0], '0fa4ce047340780f08efca92f22027514263521d')
+        self.assertEqual(pickle.loads(ds[1]).url, responses[0].url)
+        self.assertEqual(ds[2], dr[0])
+        self.assertEqual(pickle.loads(ds[3]), dr[1])
+        self.assertEqual(pickle.loads(ds[4]), dr[2])
+
+        ds = data_stored[1]
+        dr = data_requests[1]
+        self.assertEqual(ds[0], '3879a6f12828b7ac3a88b7167333e86168f2f5d2')
+        self.assertEqual(pickle.loads(ds[1]).url, responses[1].url)
+        self.assertEqual(ds[2], dr[0])
+        self.assertEqual(pickle.loads(ds[3]), dr[1])
+        self.assertEqual(pickle.loads(ds[4]), dr[2])
+
+        ds = data_stored[2]
+        dr = data_requests[2]
+        self.assertEqual(ds[0], 'ef38f574a0745b63a056e7befdb7a06e7cf1549b')
+        self.assertEqual(pickle.loads(ds[1]).url, responses[2].url)
+        self.assertEqual(ds[2], dr[0])
+        self.assertEqual(pickle.loads(ds[3]), dr[1])
+        self.assertEqual(pickle.loads(ds[4]), dr[2])
+
+    @httpretty.activate
+    def test_store_duplicate(self):
+        """Test whether the insertion of duplicated data throws an error"""
+
+        url = "https://example.com/tasks"
+        payload = {'task_id': 10}
+        headers = {'Accept': 'application/json'}
+
+        httpretty.register_uri(httpretty.GET,
+                               url,
+                               body='{"hey": "there"}',
+                               status=200)
+        response = requests.get(url, params=payload, headers=headers)
+
+        archive_path = os.path.join(self.test_path, 'myarchive')
+        archive = Archive.create(archive_path)
+
+        archive.store(url, payload, headers, response)
+
+        # check the unique index filters duplicated API calls
+        with self.assertRaisesRegex(ArchiveError, "duplicated entry"):
+            archive.store(url, payload, headers, response)
+
+    @httpretty.activate
+    def test_retrieve(self):
+        """Test whether data is properly retrieved from the archive"""
+
+        url = "https://example.com/tasks"
+        payload = {'task_id': 10}
+        headers = {'Accept': 'application/json'}
+
+        httpretty.register_uri(httpretty.GET,
+                               url,
+                               body='{"hey": "there"}',
+                               status=200)
+        response = requests.get(url, params=payload, headers=headers)
+
+        archive_path = os.path.join(self.test_path, 'myarchive')
+        archive = Archive.create(archive_path)
+        archive.store(url, payload, headers, response)
+
+        data = archive.retrieve(url, payload, headers)
+
+        self.assertEqual(data.url, response.url)
+
+    def test_retrieve_missing(self):
+        """Test whether the retrieval of non archived data throws an error
+
+        In the exceptional case of a failure in retrieving data from an archive (e.g., manual modification),
+        an exception is thrown to stop the retrieval from the archive
+        """
+
+        archive_path = os.path.join(self.test_path, 'myarchive')
+        archive = Archive.create(archive_path)
+
+        with self.assertRaisesRegex(ArchiveError, "not found in archive"):
+            _ = archive.retrieve("http://wrong", payload={}, headers={})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR simplifies the retrieval of cached data.

In a nutshell, the data returned during fetch executions is stored in different archives (one per execution) which allow to transparently play back previous fetch executions, enabling the recovery of the stored data as it was originally collected from the data source.

This PR replaces [PR 194](https://github.com/grimoirelab/perceval/pull/194)