### PR TITLE
[launchpad] Handle 404 HTTP error

### DIFF
--- a/perceval/backends/core/launchpad.py
+++ b/perceval/backends/core/launchpad.py
@@ -440,8 +440,8 @@ class LaunchpadClient(HttpClient):
             raw_user = self.__send_request(url_user, headers=self.__get_headers())
             user = raw_user
         except requests.exceptions.HTTPError as e:
-            if e.response.status_code == 410:
-                logger.warning("Data is not available due to HTTP 410 Gone - %s", url_user)
+            if e.response.status_code in [404, 410]:
+                logger.warning("Data is not available - %s", url_user)
                 user = '{}'
             else:
                 raise e
@@ -561,8 +561,8 @@ class LaunchpadClient(HttpClient):
                 raw_content = self.__send_request(url_next, payload, self.__get_headers())
                 content = json.loads(raw_content)
             except requests.exceptions.HTTPError as e:
-                if e.response.status_code == 410:
-                    logger.warning("Data is not available due to HTTP 410 Gone - %s", url_next)
+                if e.response.status_code in [410]:
+                    logger.warning("Data is not available - %s", url_next)
                     raw_content = '{"total_size": 0, "start": 0, "entries": []}'
                     content = json.loads(raw_content)
                 else:

--- a/tests/test_launchpad.py
+++ b/tests/test_launchpad.py
@@ -778,6 +778,21 @@ class TestLaunchpadClient(unittest.TestCase):
         self.assertDictEqual(json.loads(user_retrieved), json.loads(user))
 
     @httpretty.activate
+    def test_user_not_retrieved(self):
+        """Test user API call"""
+
+        httpretty.register_uri(httpretty.GET,
+                               LAUNCHPAD_API_URL + "/~user-not",
+                               body="",
+                               status=404)
+
+        client = LaunchpadClient("mydistribution", consumer_key=CONSUMER_KEY, api_token=OAUTH_TOKEN,
+                                 package="mypackage")
+
+        user_retrieved = client.user("user-not")
+        self.assertEqual(user_retrieved, "{}")
+
+    @httpretty.activate
     def test_http_wrong_status_issue_collection(self):
         """Test if an empty collection is returned when the http status is not 200"""
 


### PR DESCRIPTION
This patch allows to handle 404 http errors, which may occur when requesting data of deleted user.