### PR TITLE
[meetup] Remove 'draft' status due to a bug in Meetup API

### DIFF
--- a/perceval/backends/core/meetup.py
+++ b/perceval/backends/core/meetup.py
@@ -68,7 +68,7 @@ class Meetup(Backend):
     :param sleep_time: minimun waiting time to avoid too many request
          exception
     """
-    version = '0.6.1'
+    version = '0.7.0'
 
     def __init__(self, group, api_token, max_items=MAX_ITEMS,
                  tag=None, cache=None,
@@ -359,8 +359,9 @@ class MeetupClient(HttpClient, RateLimitHandler):
                      'plain_text_description', 'rsvpable', 'series']
     VRSVP_FIELDS = ['attendance_status']
     VRESPONSE = ['yes', 'no']
-    VSTATUS = ['cancelled', 'upcoming', 'past', 'proposed',
-               'suggested', 'draft']
+    # FIXME: Add 'draft' status when the bug in the Meetup API gets fixed.
+    # More info in https://github.com/meetup/api/issues/260
+    VSTATUS = ['cancelled', 'upcoming', 'past', 'proposed', 'suggested']
     VUPDATED = 'updated'
 
     def __init__(self, api_key, max_items=MAX_ITEMS,

--- a/tests/test_meetup.py
+++ b/tests/test_meetup.py
@@ -239,7 +239,7 @@ class TestMeetupBackend(unittest.TestCase):
                 'page': ['2'],
                 'scroll': ['since:1970-01-01T00:00:00.000Z'],
                 'sign': ['true'],
-                'status': ['cancelled,upcoming,past,proposed,suggested,draft']
+                'status': ['cancelled,upcoming,past,proposed,suggested']
             },
             {
                 'key': ['aaaa'],
@@ -324,7 +324,7 @@ class TestMeetupBackend(unittest.TestCase):
                 'page': ['2'],
                 'scroll': ['since:2016-09-25T00:00:00.000Z'],
                 'sign': ['true'],
-                'status': ['cancelled,upcoming,past,proposed,suggested,draft']
+                'status': ['cancelled,upcoming,past,proposed,suggested']
             },
             {
                 'key': ['aaaa'],
@@ -382,7 +382,7 @@ class TestMeetupBackend(unittest.TestCase):
                 'page': ['2'],
                 'scroll': ['since:1970-01-01T00:00:00.000Z'],
                 'sign': ['true'],
-                'status': ['cancelled,upcoming,past,proposed,suggested,draft']
+                'status': ['cancelled,upcoming,past,proposed,suggested']
             },
             {
                 'key': ['aaaa'],
@@ -465,7 +465,7 @@ class TestMeetupBackend(unittest.TestCase):
                 'page': ['2'],
                 'scroll': ['since:2016-04-08T00:00:00.000Z'],
                 'sign': ['true'],
-                'status': ['cancelled,upcoming,past,proposed,suggested,draft']
+                'status': ['cancelled,upcoming,past,proposed,suggested']
             },
             {
                 'key': ['aaaa'],
@@ -507,7 +507,7 @@ class TestMeetupBackend(unittest.TestCase):
             'page': ['2'],
             'scroll': ['since:2017-01-01T00:00:00.000Z'],
             'sign': ['true'],
-            'status': ['cancelled,upcoming,past,proposed,suggested,draft']
+            'status': ['cancelled,upcoming,past,proposed,suggested']
         }
 
         self.assertEqual(len(http_requests), 1)
@@ -700,7 +700,7 @@ class TestMeetupClient(unittest.TestCase):
                 'page': ['2'],
                 'scroll': ['since:2016-01-01T00:00:00.000Z'],
                 'sign': ['true'],
-                'status': ['cancelled,upcoming,past,proposed,suggested,draft']
+                'status': ['cancelled,upcoming,past,proposed,suggested']
             },
             {
                 'key': ['aaaa'],
@@ -803,7 +803,7 @@ class TestMeetupClient(unittest.TestCase):
                 'page': ['2'],
                 'scroll': ['since:1970-01-01T00:00:00.000Z'],
                 'sign': ['true'],
-                'status': ['cancelled,upcoming,past,proposed,suggested,draft']
+                'status': ['cancelled,upcoming,past,proposed,suggested']
             },
             {
                 'key': ['aaaa'],
@@ -841,7 +841,7 @@ class TestMeetupClient(unittest.TestCase):
             'page': ['2'],
             'scroll': ['since:1970-01-01T00:00:00.000Z'],
             'sign': ['true'],
-            'status': ['cancelled,upcoming,past,proposed,suggested,draft']
+            'status': ['cancelled,upcoming,past,proposed,suggested']
         }
 
         self.assertEqual(len(http_requests), 1)


### PR DESCRIPTION
This is a work around to fix the problem with Meetup API.
In some cases, having this status in the list of requested
events, makes the API to return zero events.

The bug was reported in https://github.com/meetup/api/issues/260.
As soon as it gets fixed, we will add it back again to the list
of requested events.

Backend version updated to 0.7.0.

Partially fixes #261 