### PR TITLE
[git] Fix cloned directory of local repository

### DIFF
--- a/perceval/backends/core/git.py
+++ b/perceval/backends/core/git.py
@@ -288,7 +288,8 @@ class GitCommand(BackendCommand):
             git_path = self.parsed_args.git_log
         elif not self.parsed_args.git_path:
             base_path = os.path.expanduser('~/.perceval/repositories/')
-            git_path = os.path.join(base_path, self.parsed_args.uri) + '-git'
+            processed_uri = self.parsed_args.uri.lstrip('/')
+            git_path = os.path.join(base_path, processed_uri) + '-git'
         else:
             git_path = self.parsed_args.git_path
 

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -624,6 +624,12 @@ class TestGitCommand(TestCaseGit):
         cmd = GitCommand(*args)
         self.assertEqual(cmd.parsed_args.gitpath, '/tmp/gitpath')
 
+        args = ['/tmp/gitpath/']
+
+        cmd = GitCommand(*args)
+        self.assertEqual(cmd.parsed_args.gitpath,
+                         os.path.join(self.tmp_path, 'testpath/tmp/gitpath/' + '-git'))
+
     def test_setup_cmd_parser(self):
         """Test if it parser object is correctly initialized"""
 


### PR DESCRIPTION
This patch fixes the issue #262. The git_path is derived by joining the default Perceval location plus the path of the local Git repository to analyse, stripped of the initial slash. 
The initial slash in a component of a os.path.join causes all previous components to be thrown away and the joining continues from the absolute path component.