### PR TITLE
[http-client] Modify HttpClient variable name default_sleep_time

### DIFF
--- a/perceval/backends/core/jenkins.py
+++ b/perceval/backends/core/jenkins.py
@@ -54,7 +54,7 @@ class Jenkins(Backend):
     :param blacklist_jobs: exclude the jobs of this list while fetching
     :param sleep_time: minimun waiting time due to a timeout connection exception
     """
-    version = '0.6.1'
+    version = '0.7.0'
 
     def __init__(self, url, tag=None, cache=None, blacklist_jobs=None, sleep_time=SLEEP_TIME):
         origin = url
@@ -197,7 +197,7 @@ class JenkinsClient(HttpClient):
     MAX_RETRIES = 5
 
     def __init__(self, url, blacklist_jobs=None, sleep_time=SLEEP_TIME):
-        super().__init__(url, default_sleep_time=sleep_time, extra_status_forcelist=[410, 502, 503])
+        super().__init__(url, sleep_time=sleep_time, extra_status_forcelist=[410, 502, 503])
         self.blacklist_jobs = blacklist_jobs
 
     def get_jobs(self):

--- a/perceval/backends/core/launchpad.py
+++ b/perceval/backends/core/launchpad.py
@@ -65,7 +65,7 @@ class Launchpad(Backend):
     :param min_rate_to_sleep: minimun rate needed to sleep until
            it will be reset
     """
-    version = '0.2.0'
+    version = '0.3.0'
 
     def __init__(self, distribution, package=None,
                  consumer_key=None, api_token=None,
@@ -410,7 +410,7 @@ class LaunchpadClient(HttpClient):
     def __init__(self, distribution, package=None,
                  consumer_key=None, api_token=None,
                  items_per_page=ITEMS_PER_PAGE, sleep_time=SLEEP_TIME):
-        super().__init__(LAUNCHPAD_API_URL, default_sleep_time=sleep_time)
+        super().__init__(LAUNCHPAD_API_URL, sleep_time=sleep_time)
         self.consumer_key = consumer_key
         self.api_token = api_token
         self.distribution = distribution

--- a/perceval/backends/core/meetup.py
+++ b/perceval/backends/core/meetup.py
@@ -69,7 +69,7 @@ class Meetup(Backend):
     :param sleep_time: minimun waiting time to avoid too many request
          exception
     """
-    version = '0.7.0'
+    version = '0.8.0'
 
     def __init__(self, group, api_token, max_items=MAX_ITEMS,
                  tag=None, cache=None,
@@ -370,7 +370,7 @@ class MeetupClient(HttpClient, RateLimitHandler):
         self.api_key = api_key
         self.max_items = max_items
 
-        super().__init__(MEETUP_API_URL, default_sleep_time=sleep_time, extra_status_forcelist=[429])
+        super().__init__(MEETUP_API_URL, sleep_time=sleep_time, extra_status_forcelist=[429])
         super().setup_rate_limit_handler(sleep_for_rate=sleep_for_rate, min_rate_to_sleep=min_rate_to_sleep)
 
     def calculate_time_to_reset(self):

--- a/perceval/client.py
+++ b/perceval/client.py
@@ -50,7 +50,7 @@ class HttpClient:
     :param base_url: base URL of the data source
     :param max_retries: number of max retries to a data source
         before raising a RetryError exception
-    :param default_sleep_time: default time to sleep in case
+    :param sleep_time: time to sleep in case
         of connection problems
     """
     version = '0.1.1'
@@ -76,7 +76,7 @@ class HttpClient:
     GET = "GET"
     POST = "POST"
 
-    def __init__(self, base_url, max_retries=MAX_RETRIES, default_sleep_time=DEFAULT_SLEEP_TIME,
+    def __init__(self, base_url, max_retries=MAX_RETRIES, sleep_time=DEFAULT_SLEEP_TIME,
                  extra_headers=None, extra_status_forcelist=None, extra_retry_after_status=None):
 
         self.base_url = base_url
@@ -103,7 +103,7 @@ class HttpClient:
         self.raise_on_redirect = self.DEFAULT_RAISE_ON_REDIRECT
         self.raise_on_status = self.DEFAULT_RAISE_ON_STATUS
         self.respect_retry_after_header = self.DEFAULT_RESPECT_RETRY_AFTER_HEADER
-        self.default_sleep_time = default_sleep_time
+        self.sleep_time = sleep_time
 
         self._create_http_session()
 
@@ -147,7 +147,7 @@ class HttpClient:
                                      status=self.max_retries_on_status,
                                      method_whitelist=self.method_whitelist,
                                      status_forcelist=self.status_forcelist,
-                                     backoff_factor=self.default_sleep_time,
+                                     backoff_factor=self.sleep_time,
                                      raise_on_redirect=self.raise_on_redirect,
                                      raise_on_status=self.raise_on_status,
                                      respect_retry_after_header=self.respect_retry_after_header)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -47,7 +47,7 @@ CLIENT_IRONMAN_URL = "https://gateway.marvel.com/v1/public/characters/4"
 
 class MockedClient(HttpClient, RateLimitHandler):
 
-    def __init__(self, base_url, default_sleep_time=HttpClient.DEFAULT_SLEEP_TIME,
+    def __init__(self, base_url, sleep_time=HttpClient.DEFAULT_SLEEP_TIME,
                  max_retries=HttpClient.MAX_RETRIES,
                  extra_status_forcelist=None,
                  extra_retry_after_status=None,
@@ -56,7 +56,7 @@ class MockedClient(HttpClient, RateLimitHandler):
                  rate_limit_header=RateLimitHandler.RATE_LIMIT_HEADER,
                  rate_limit_reset_header=RateLimitHandler.RATE_LIMIT_RESET_HEADER):
 
-        super().__init__(base_url, default_sleep_time=default_sleep_time, max_retries=max_retries,
+        super().__init__(base_url, sleep_time=sleep_time, max_retries=max_retries,
                          extra_status_forcelist=extra_status_forcelist,
                          extra_retry_after_status=extra_retry_after_status,
                          extra_headers=extra_headers)
@@ -87,7 +87,7 @@ class TestHttpClient(unittest.TestCase):
         self.assertEqual(client.raise_on_redirect, HttpClient.DEFAULT_RAISE_ON_REDIRECT)
         self.assertEqual(client.raise_on_status, HttpClient.DEFAULT_RAISE_ON_STATUS)
         self.assertEqual(client.respect_retry_after_header, HttpClient.DEFAULT_RESPECT_RETRY_AFTER_HEADER)
-        self.assertEqual(client.default_sleep_time, HttpClient.DEFAULT_SLEEP_TIME)
+        self.assertEqual(client.sleep_time, HttpClient.DEFAULT_SLEEP_TIME)
 
         self.assertIsNotNone(client.session)
         self.assertEqual(client.session.headers['User-Agent'], HttpClient.DEFAULT_HEADERS.get('User-Agent'))
@@ -102,7 +102,7 @@ class TestHttpClient(unittest.TestCase):
 
         client = MockedClient(CLIENT_API_URL,
                               max_retries=expected_retries,
-                              default_sleep_time=expected_sleep_time,
+                              sleep_time=expected_sleep_time,
                               extra_headers=expected_headers,
                               extra_retry_after_status=[extra_status],
                               extra_status_forcelist=[extra_status])
@@ -110,7 +110,7 @@ class TestHttpClient(unittest.TestCase):
         self.assertEqual(client.session.headers['User-Agent'], expected_headers.get('User-Agent'))
         self.assertEqual(client.session.headers['Token'], expected_headers.get('Token'))
         self.assertEqual(client.max_retries, expected_retries)
-        self.assertEqual(client.default_sleep_time, expected_sleep_time)
+        self.assertEqual(client.sleep_time, expected_sleep_time)
         self.assertTrue(extra_status in client.status_forcelist)
         self.assertTrue(extra_status in client.retry_after_status)
 
@@ -138,7 +138,7 @@ class TestHttpClient(unittest.TestCase):
                                body=output,
                                status=200)
 
-        client = MockedClient(CLIENT_API_URL, default_sleep_time=0.1, max_retries=1)
+        client = MockedClient(CLIENT_API_URL, sleep_time=0.1, max_retries=1)
         response = client.fetch(CLIENT_SPIDERMAN_URL)
 
         self.assertEqual(response.request.method, HttpClient.GET)
@@ -153,7 +153,7 @@ class TestHttpClient(unittest.TestCase):
                                body="",
                                status=403)
 
-        client = MockedClient(CLIENT_API_URL, default_sleep_time=0.1, max_retries=1)
+        client = MockedClient(CLIENT_API_URL, sleep_time=0.1, max_retries=1)
 
         with self.assertRaises(requests.exceptions.HTTPError):
             _ = client.fetch(CLIENT_SUPERMAN_URL)
@@ -169,7 +169,7 @@ class TestHttpClient(unittest.TestCase):
                                body=output,
                                status=200)
 
-        client = MockedClient(CLIENT_API_URL, default_sleep_time=0.1, max_retries=1)
+        client = MockedClient(CLIENT_API_URL, sleep_time=0.1, max_retries=1)
 
         response = client.fetch(CLIENT_SPIDERMAN_URL, method=HttpClient.POST)
         self.assertEqual(response.request.method, HttpClient.POST)
@@ -205,7 +205,7 @@ class TestHttpClient(unittest.TestCase):
                                    'Retry-After': str(retry_after_value)
                                })
 
-        client = MockedClient(CLIENT_API_URL, default_sleep_time=0.1, max_retries=1)
+        client = MockedClient(CLIENT_API_URL, sleep_time=0.1, max_retries=1)
 
         urls = [CLIENT_SPIDERMAN_URL, CLIENT_SUPERMAN_URL, CLIENT_BATMAN_URL]
 
@@ -243,7 +243,7 @@ class TestHttpClient(unittest.TestCase):
                                body="",
                                status=504)
 
-        client = MockedClient(CLIENT_API_URL, default_sleep_time=0.1, max_retries=1, extra_status_forcelist=[301])
+        client = MockedClient(CLIENT_API_URL, sleep_time=0.1, max_retries=1, extra_status_forcelist=[301])
 
         urls = [CLIENT_IRONMAN_URL, CLIENT_SPIDERMAN_URL, CLIENT_SUPERMAN_URL, CLIENT_BATMAN_URL]
 
@@ -258,7 +258,7 @@ class TestRateLimitHandler(unittest.TestCase):
     def test_setup_rate_limit_handler(self):
         """Test whether variables are properly initialized during the setup"""
 
-        client = MockedClient(CLIENT_API_URL, default_sleep_time=0.1, max_retries=1)
+        client = MockedClient(CLIENT_API_URL, sleep_time=0.1, max_retries=1)
 
         self.assertEqual(client.sleep_for_rate, False)
         self.assertEqual(client.min_rate_to_sleep, RateLimitHandler.MIN_RATE_LIMIT)
@@ -270,7 +270,7 @@ class TestRateLimitHandler(unittest.TestCase):
         expected_rate_limit_header = "ACME Corp."
         expected_rate_limit_reset_header = "UMBRELLA Corp."
 
-        client = MockedClient(CLIENT_API_URL, default_sleep_time=0.1, max_retries=1,
+        client = MockedClient(CLIENT_API_URL, sleep_time=0.1, max_retries=1,
                               sleep_for_rate=expected_sleep_for_rate,
                               min_rate_to_sleep=expected_min_rate_to_sleep,
                               rate_limit_header=expected_rate_limit_header,
@@ -283,7 +283,7 @@ class TestRateLimitHandler(unittest.TestCase):
 
         expected_min_rate_to_sleep = 1000
         client = MockedClient(CLIENT_API_URL, min_rate_to_sleep=expected_min_rate_to_sleep,
-                              default_sleep_time=0.1, max_retries=1)
+                              sleep_time=0.1, max_retries=1)
         self.assertEqual(client.min_rate_to_sleep, min(expected_min_rate_to_sleep, RateLimitHandler.MAX_RATE_LIMIT))
 
     @httpretty.activate
@@ -304,14 +304,14 @@ class TestRateLimitHandler(unittest.TestCase):
                                body="",
                                status=200)
 
-        client = MockedClient(CLIENT_API_URL, default_sleep_time=0.1, max_retries=1)
+        client = MockedClient(CLIENT_API_URL, sleep_time=0.1, max_retries=1)
         response = client.fetch(CLIENT_SPIDERMAN_URL)
         client.update_rate_limit(response)
 
         self.assertEqual(client.rate_limit, 20)
         self.assertEqual(client.rate_limit_reset_ts, 15)
 
-        client = MockedClient(CLIENT_API_URL, default_sleep_time=0.1, max_retries=1)
+        client = MockedClient(CLIENT_API_URL, sleep_time=0.1, max_retries=1)
         response = client.fetch(CLIENT_SUPERMAN_URL)
         client.update_rate_limit(response)
 
@@ -337,7 +337,7 @@ class TestRateLimitHandler(unittest.TestCase):
                                body="",
                                status=200)
 
-        client = MockedClient(CLIENT_API_URL, min_rate_to_sleep=50, default_sleep_time=0.1, max_retries=1)
+        client = MockedClient(CLIENT_API_URL, min_rate_to_sleep=50, sleep_time=0.1, max_retries=1)
         response = client.fetch(CLIENT_SPIDERMAN_URL)
         client.update_rate_limit(response)
 

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -869,7 +869,7 @@ class TestGitHubClient(unittest.TestCase):
         self.assertEqual(client.owner, 'zhquan_example')
         self.assertEqual(client.repository, 'repo')
         self.assertEqual(client.max_retries, GitHubClient.MAX_RETRIES)
-        self.assertEqual(client.default_sleep_time, GitHubClient.DEFAULT_SLEEP_TIME)
+        self.assertEqual(client.sleep_time, GitHubClient.DEFAULT_SLEEP_TIME)
         self.assertEqual(client.max_retries, GitHubClient.MAX_RETRIES)
         self.assertEqual(client.base_url, 'https://api.github.com')
 
@@ -1239,7 +1239,7 @@ class TestGitHubClient(unittest.TestCase):
                                    'X-RateLimit-Reset': '15'
                                })
 
-        client = GitHubClient("zhquan_example", "repo", "aaa", default_sleep_time=1, max_retries=1)
+        client = GitHubClient("zhquan_example", "repo", "aaa", sleep_time=1, max_retries=1)
 
         with self.assertRaises(requests.exceptions.HTTPError):
             _ = [issues for issues in client.issues()]
@@ -1377,7 +1377,7 @@ class TestGitHubCommand(unittest.TestCase):
         args = ['--sleep-for-rate',
                 '--min-rate-to-sleep', '1',
                 '--max-retries', '5',
-                '--default-sleep-time', '10',
+                '--sleep-time', '10',
                 '--tag', 'test', '--no-cache',
                 '--api-token', 'abcdefgh',
                 '--from-date', '1970-01-01',
@@ -1390,7 +1390,7 @@ class TestGitHubCommand(unittest.TestCase):
         self.assertEqual(parsed_args.base_url, 'https://example.com')
         self.assertEqual(parsed_args.sleep_for_rate, True)
         self.assertEqual(parsed_args.max_retries, 5)
-        self.assertEqual(parsed_args.default_sleep_time, 10)
+        self.assertEqual(parsed_args.sleep_time, 10)
         self.assertEqual(parsed_args.tag, 'test')
         self.assertEqual(parsed_args.from_date, DEFAULT_DATETIME)
         self.assertEqual(parsed_args.no_cache, True)

--- a/tests/test_jenkins.py
+++ b/tests/test_jenkins.py
@@ -80,7 +80,7 @@ class TestJenkinsBackend(unittest.TestCase):
         self.assertEqual(jenkins.origin, JENKINS_SERVER_URL)
         self.assertEqual(jenkins.tag, 'test')
         self.assertIsInstance(jenkins.client, JenkinsClient)
-        self.assertEqual(jenkins.client.default_sleep_time, 60)
+        self.assertEqual(jenkins.client.sleep_time, 60)
 
         # When tag is empty or None it will be set to
         # the value in url
@@ -365,7 +365,7 @@ class TestJenkinsClient(unittest.TestCase):
 
         self.assertEqual(client.base_url, JENKINS_SERVER_URL)
         self.assertEqual(client.blacklist_jobs, None)
-        self.assertEqual(client.default_sleep_time, target_sleep_time)
+        self.assertEqual(client.sleep_time, target_sleep_time)
 
     @httpretty.activate
     def test_http_retry_requests(self):
@@ -378,7 +378,7 @@ class TestJenkinsClient(unittest.TestCase):
         client = JenkinsClient(JENKINS_SERVER_URL, sleep_time=0.1)
 
         before = float(time.time())
-        expected = before + (client.default_sleep_time * JenkinsClient.MAX_RETRIES)
+        expected = before + (client.sleep_time * JenkinsClient.MAX_RETRIES)
 
         with self.assertRaises(requests.exceptions.RetryError):
             _ = client.get_jobs()
@@ -429,7 +429,7 @@ class TestJenkinsClient(unittest.TestCase):
         client = JenkinsClient(JENKINS_SERVER_URL, sleep_time=0.1)
 
         start = float(time.time())
-        expected = start + (sum([i * client.default_sleep_time for i in range(client.MAX_RETRIES)]))
+        expected = start + (sum([i * client.sleep_time for i in range(client.MAX_RETRIES)]))
 
         with self.assertRaises(requests.exceptions.RequestException):
             _ = client.get_builds(JENKINS_JOB_BUILDS_1)

--- a/tests/test_meetup.py
+++ b/tests/test_meetup.py
@@ -181,7 +181,7 @@ class TestMeetupBackend(unittest.TestCase):
         self.assertEqual(meetup.client.api_key, 'aaaa')
         self.assertEqual(meetup.client.sleep_for_rate, True)
         self.assertEqual(meetup.client.min_rate_to_sleep, 10)
-        self.assertEqual(meetup.client.default_sleep_time, 60)
+        self.assertEqual(meetup.client.sleep_time, 60)
 
         # When tag is empty or None it will be set to
         # the value in URL
@@ -891,7 +891,7 @@ class TestMeetupClient(unittest.TestCase):
 
         client = MeetupClient('aaaa', max_items=2, sleep_time=0.1)
         start = float(time.time())
-        expected = start + (sum([i * client.default_sleep_time for i in range(client.MAX_RETRIES)]))
+        expected = start + (sum([i * client.sleep_time for i in range(client.MAX_RETRIES)]))
 
         events = client.events('sqlpass-es')
         with self.assertRaises(requests.exceptions.RetryError):


### PR DESCRIPTION
This PR changes the variable name _default_sleep_time_ to _sleep_time_ in the HttpClient and in some backends (GitHub, Launchpad, Jenkins and Meetup) in order to ensure compatibility with mordred configuration files
