### PR TITLE
Additional pattern for moved files in Git

### DIFF
--- a/perceval/backends/core/git.py
+++ b/perceval/backends/core/git.py
@@ -651,10 +651,14 @@ class GitParser:
     def __get_old_filepath(self, f):
         """Get the old filepath of a moved/renamed file.
 
-        Moved or renamed files can be found in the log with the next
-        patterns: '{old_prefix => new_prefix}/name' or
-        'name/{old_suffix => new_suffix}'. This method returns the
-        filepath before the file was moved or renamed.
+        Moved or renamed files can be found in the log with any of the
+        next patterns:
+          'old_name => new_name'
+          '{old_prefix => new_prefix}/name'
+          'name/{old_suffix => new_suffix}'
+
+        This method returns the filepath before the file was moved or
+        renamed.
         """
         i = f.find('{')
         j = f.find('}')
@@ -664,6 +668,8 @@ class GitParser:
             inner = f[i + 1:f.find(' => ', i)]
             suffix = f[j + 1:]
             return prefix + inner + suffix
+        elif ' => ' in f:
+            return f.split(' => ')[0]
         else:
             return f
 

--- a/tests/data/git/git_log.txt
+++ b/tests/data/git/git_log.txt
@@ -106,3 +106,16 @@ CommitDate: Tue Aug 14 14:30:13 2012 -0300
 0	0	aaa/otherthing
 0	0	aaa/something
 0	0	bbb/bthing
+
+commit 49345fe87bd1dfad7e682f6554f7472c5576a8c7
+Author:     Eduardo Morais <companheiro.vermelho@example.com>
+AuthorDate: Tue Jan 9 15:30:49 2018 +0100
+Commit:     Eduardo Morais <companheiro.vermelho@example.com>
+CommitDate: Tue Jan 9 15:30:49 2018 +0100
+
+    Moving things around
+
+:100644 100644 802992c... 802992c... R100	src1/file3.txt	src3/file3.txt
+:100644 100644 802992c... 802992c... R100	src2/file2.txt	src3/file4.txt
+0	0	{src1 => src3}/file3.txt
+0	0	src2/file2.txt => src3/file4.txt

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -501,7 +501,8 @@ class TestGitBackend(TestCaseGit):
                     ('c0d66f92a95e31c77be08dc9d0f11a16715d1885', 1344965702.0),
                     ('7debcf8a2f57f86663809c58b5c07a398be7674c', 1344965607.0),
                     ('87783129c3f00d2c81a3a8e585eb86a47e39891a', 1344965535.0),
-                    ('bc57a9209f096a130dcc5ba7089a8663f758a703', 1344965413.0)]
+                    ('bc57a9209f096a130dcc5ba7089a8663f758a703', 1344965413.0),
+                    ('49345fe87bd1dfad7e682f6554f7472c5576a8c7', 1515508249.0)]
 
         self.assertEqual(len(commits), len(expected))
 
@@ -530,7 +531,8 @@ class TestGitBackend(TestCaseGit):
                     'c0d66f92a95e31c77be08dc9d0f11a16715d1885',
                     '7debcf8a2f57f86663809c58b5c07a398be7674c',
                     '87783129c3f00d2c81a3a8e585eb86a47e39891a',
-                    'bc57a9209f096a130dcc5ba7089a8663f758a703']
+                    'bc57a9209f096a130dcc5ba7089a8663f758a703',
+                    '49345fe87bd1dfad7e682f6554f7472c5576a8c7']
 
         self.assertListEqual(result, expected)
 
@@ -669,7 +671,7 @@ class TestGitParser(TestCaseGit):
             parser = GitParser(f)
             commits = [commit for commit in parser.parse()]
 
-        self.assertEqual(len(commits), 9)
+        self.assertEqual(len(commits), 10)
 
         expected = {
             'commit': '456a68ee1407a77f3e804a30dff245bb6c6b872f',
@@ -726,6 +728,39 @@ class TestGitParser(TestCaseGit):
             ]
         }
         self.assertDictEqual(commits[5], expected)
+
+        expected = {
+            'commit': '49345fe87bd1dfad7e682f6554f7472c5576a8c7',
+            'parents': [],
+            'refs': [],
+            'Author': 'Eduardo Morais <companheiro.vermelho@example.com>',
+            'AuthorDate': 'Tue Jan 9 15:30:49 2018 +0100',
+            'Commit': 'Eduardo Morais <companheiro.vermelho@example.com>',
+            'CommitDate': 'Tue Jan 9 15:30:49 2018 +0100',
+            'message': 'Moving things around',
+            'files': [
+                {
+                    'file': 'src1/file3.txt',
+                    'newfile': 'src3/file3.txt',
+                    'added': '0',
+                    'removed': '0',
+                    'modes': ['100644', '100644'],
+                    'indexes': ['802992c...', '802992c...'],
+                    'action': 'R100'
+                },
+                {
+                    'file': 'src2/file2.txt',
+                    'newfile': 'src3/file4.txt',
+                    'added': '0',
+                    'removed': '0',
+                    'modes': ['100644', '100644'],
+                    'indexes': ['802992c...', '802992c...'],
+                    'action': 'R100'
+                }
+            ]
+        }
+
+        self.assertDictEqual(commits[9], expected)
 
     def test_parser_merge_commit(self):
         """Test if it parses all the available data on a merge commit"""


### PR DESCRIPTION
There is a pattern for moved files in Git that is not captured by Perceval.

When the destination directory *and* filename are both different, the pattern in the stats part of the Git log is like the following:

```
dir1/file1.txt => dir2/file2.txt
```

For instance, with this commit log (extracted from this commit: https://github.com/iht/test/commit/49345fe87bd1dfad7e682f6554f7472c5576a8c7):
```
commit 49345fe87bd1dfad7e682f6554f7472c5576a8c7 ed4157f5e8fb9807a0dc9f03f85bd6b3019ed763 (HEAD -> refs/heads/master)
Author:     Israel Herraiz <israel.herraiz@bbvadata.com>
AuthorDate: Tue Jan 9 15:30:49 2018 +0100
Commit:     Israel Herraiz <israel.herraiz@bbvadata.com>
CommitDate: Tue Jan 9 15:30:49 2018 +0100

    Moving things around

:100644 100644 802992c... 802992c... R100       src1/file3.txt  src3/file3.txt
:100644 100644 802992c... 802992c... R100       src2/file2.txt  src3/file4.txt
0       0       {src1 => src3}/file3.txt
0       0       src2/file2.txt => src3/file4.txt
```

In the `files` dictionary, Perceval will create 3 items (instead of 2). The additional *file* will have name `src2/file2.txt => src3/file4.txt`. One of the items will have the `stats` part of the log, and the other item the `actions` part:

```
   {
        "modes": [
            "100644",
            "100644"
        ],
        "indexes": [
            "802992c...",
            "802992c..."
        ],
        "action": "R100",
        "file": "src2/file2.txt",
        "newfile": "src3/file4.txt"
    },
    {
        "file": "src2/file2.txt => src3/file4.txt",
        "added": "0",
        "removed": "0"
    }
```

This pull request fixes this problem, by adding an additional pattern for moved files to the `stats` parsing. I have added a new test case for this specific pattern.