### PR TITLE
[backend] Change method signature of _test_fetch_from_archive

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -41,10 +41,10 @@ class TestCaseBackendArchive(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(self.test_path)
 
-    def _test_fetch_from_archive(self, category, **kwargs):
+    def _test_fetch_from_archive(self, **kwargs):
         """Test whether the method fetch_from_archive works properly"""
 
-        items = [items for items in self.backend.fetch(category=category, **kwargs)]
+        items = [items for items in self.backend.fetch(**kwargs)]
         items_archived = [item for item in self.backend.fetch_from_archive()]
 
         self.assertEqual(len(items), len(items_archived))

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -65,6 +65,9 @@ class MockedBackend(Backend):
             item = {'item': x}
             yield item
 
+    def fetch(self):
+        return super().fetch(MockedBackend.CATEGORY)
+
     @metadata
     def fetch_from_cache(self):
         for x in range(5):
@@ -254,7 +257,7 @@ class TestBackendArchive(TestCaseBackendArchive):
     def test_fetch_from_archive(self):
         """Test whether the method fetch_from_archive works properly"""
 
-        self._test_fetch_from_archive(self.backend.CATEGORY)
+        self._test_fetch_from_archive()
 
     def test_fetch_from_archive_not_provided(self):
         """Test whether an exception is thrown when an archive is not provided"""
@@ -638,7 +641,7 @@ class TestMetadata(unittest.TestCase):
     def test_decorator(self):
         backend = MockedBackend('test', 'mytag')
         before = datetime.datetime.utcnow().timestamp()
-        items = [item for item in backend.fetch(category=MockedBackend.CATEGORY)]
+        items = [item for item in backend.fetch()]
         after = datetime.datetime.utcnow().timestamp()
 
         for x in range(5):


### PR DESCRIPTION
This code changes the method signature in tests/base.py to accept parameters beyond the item category name (which is added in the fetch method in each specific backend)