### PR TITLE
[hypermail, bugzilla] Avoid warning by BeautifulSoup.

### DIFF
--- a/perceval/backends/core/bugzilla.py
+++ b/perceval/backends/core/bugzilla.py
@@ -269,7 +269,7 @@ class Bugzilla(Backend):
             return s
 
         # Parsing starts here
-        bs = bs4.BeautifulSoup(raw_html)
+        bs = bs4.BeautifulSoup(raw_html, 'html.parser')
 
         if is_activity_empty(bs):
             fields = []

--- a/perceval/backends/core/pipermail.py
+++ b/perceval/backends/core/pipermail.py
@@ -250,7 +250,7 @@ class PipermailList(MailingList):
         return [a[1] for a in archives]
 
     def _parse_archive_links(self, raw_html):
-        bs = bs4.BeautifulSoup(raw_html)
+        bs = bs4.BeautifulSoup(raw_html, 'html.parser')
 
         candidates = [a['href'] for a in bs.find_all('a', href=True)]
         links = []


### PR DESCRIPTION
When running before this patch, the hypermail and bugzilla backends produce this warning:

```
/usr/local/lib/python3.5/dist-packages/bs4/__init__.py:181: UserWarning: No parser was explicitly specified, so I'm using the best available HTML parser for this system ("html.parser"). This usually isn't a problem, but if you run this code on another system, or in a different virtual environment, it may use a different parser and behave differently.

The code that caused this warning is on line 882 of the file /usr/lib/python3.5/threading.py. To get rid of this warning, change code that looks like this:

 BeautifulSoup(YOUR_MARKUP})

to this:

 BeautifulSoup(YOUR_MARKUP, "html.parser")

  markup_type=markup_type))
```

This patch just does that.