### PR TITLE
[jenkins] Update perceval sample in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ $ perceval hyperkitty 'https://lists.mailman3.org/archives/list/mailman-users@ma
 
 ### Jenkins
 ```
-$ perceval jenkins 'http://jenkins.cyanogenmod.org/'
+$ perceval jenkins 'https://build.opnfv.org/ci/'
 ```
 
 ### JIRA


### PR DESCRIPTION
This patch targets issue #277. It updates the link used to showcase the Perceval backend for Jenkins in the readme file. Now the backend is tested with https://build.opnfv.org/ci/